### PR TITLE
feat(backtester): add backtesting engine for strategy validation (Pha…

### DIFF
--- a/keryxflow/__init__.py
+++ b/keryxflow/__init__.py
@@ -1,3 +1,3 @@
 """KeryxFlow - A hybrid AI & quantitative trading engine."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/keryxflow/backtester/__init__.py
+++ b/keryxflow/backtester/__init__.py
@@ -1,0 +1,12 @@
+"""Backtesting module for strategy validation."""
+
+from keryxflow.backtester.data import DataLoader
+from keryxflow.backtester.engine import BacktestEngine
+from keryxflow.backtester.report import BacktestReporter, BacktestResult
+
+__all__ = [
+    "BacktestEngine",
+    "BacktestReporter",
+    "BacktestResult",
+    "DataLoader",
+]

--- a/keryxflow/backtester/data.py
+++ b/keryxflow/backtester/data.py
@@ -1,0 +1,203 @@
+"""Data loading utilities for backtesting."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pandas as pd
+
+from keryxflow.core.logging import get_logger
+from keryxflow.exchange.client import ExchangeClient
+
+logger = get_logger(__name__)
+
+
+class DataLoader:
+    """Loads historical OHLCV data for backtesting."""
+
+    REQUIRED_COLUMNS = ["datetime", "open", "high", "low", "close", "volume"]
+
+    def __init__(self, exchange_client: ExchangeClient | None = None):
+        """Initialize the data loader."""
+        self.exchange = exchange_client
+
+    async def load_from_exchange(
+        self,
+        symbol: str,
+        start: datetime,
+        end: datetime,
+        timeframe: str = "1h",
+    ) -> pd.DataFrame:
+        """
+        Load historical OHLCV data from exchange.
+
+        Args:
+            symbol: Trading pair (e.g., "BTC/USDT")
+            start: Start datetime (UTC)
+            end: End datetime (UTC)
+            timeframe: Candle timeframe (e.g., "1m", "1h", "1d")
+
+        Returns:
+            DataFrame with OHLCV data
+        """
+        if self.exchange is None:
+            raise ValueError("Exchange client required for loading from exchange")
+
+        logger.info(
+            "loading_historical_data",
+            symbol=symbol,
+            start=start.isoformat(),
+            end=end.isoformat(),
+            timeframe=timeframe,
+        )
+
+        # Fetch OHLCV data
+        all_candles = []
+        current_start = start
+
+        while current_start < end:
+            candles = await self.exchange.get_ohlcv(
+                symbol=symbol,
+                timeframe=timeframe,
+                since=int(current_start.timestamp() * 1000),
+                limit=1000,
+            )
+
+            if not candles:
+                break
+
+            all_candles.extend(candles)
+
+            # Move to next batch
+            last_timestamp = candles[-1][0]
+            current_start = datetime.fromtimestamp(last_timestamp / 1000, tz=UTC)
+
+            # Avoid infinite loop
+            if len(candles) < 1000:
+                break
+
+        if not all_candles:
+            raise ValueError(f"No data found for {symbol} in specified range")
+
+        # Convert to DataFrame
+        df = pd.DataFrame(
+            all_candles,
+            columns=["timestamp", "open", "high", "low", "close", "volume"],
+        )
+
+        # Convert timestamp to datetime
+        df["datetime"] = pd.to_datetime(df["timestamp"], unit="ms", utc=True)
+        df = df.drop(columns=["timestamp"])
+
+        # Filter to requested range
+        df = df[(df["datetime"] >= start) & (df["datetime"] <= end)]
+
+        # Sort and reset index
+        df = df.sort_values("datetime").reset_index(drop=True)
+
+        logger.info("data_loaded", symbol=symbol, candles=len(df))
+
+        return df
+
+    def load_from_csv(self, path: str | Path) -> pd.DataFrame:
+        """
+        Load OHLCV data from CSV file.
+
+        Expected CSV format:
+        datetime,open,high,low,close,volume
+        2024-01-01 00:00:00,42000.0,42100.0,41900.0,42050.0,100.5
+
+        Args:
+            path: Path to CSV file
+
+        Returns:
+            DataFrame with OHLCV data
+        """
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"CSV file not found: {path}")
+
+        logger.info("loading_csv", path=str(path))
+
+        df = pd.read_csv(path)
+
+        # Validate columns
+        if not self.validate_data(df):
+            raise ValueError(f"Invalid CSV format. Required columns: {self.REQUIRED_COLUMNS}")
+
+        # Parse datetime
+        df["datetime"] = pd.to_datetime(df["datetime"], utc=True)
+
+        # Sort and reset index
+        df = df.sort_values("datetime").reset_index(drop=True)
+
+        logger.info("csv_loaded", candles=len(df))
+
+        return df
+
+    def validate_data(self, df: pd.DataFrame) -> bool:
+        """
+        Validate that DataFrame has required OHLCV columns.
+
+        Args:
+            df: DataFrame to validate
+
+        Returns:
+            True if valid, False otherwise
+        """
+        # Check required columns exist
+        missing = set(self.REQUIRED_COLUMNS) - set(df.columns)
+        if missing:
+            logger.warning("missing_columns", columns=list(missing))
+            return False
+
+        # Check for null values in required columns
+        for col in self.REQUIRED_COLUMNS:
+            if df[col].isna().any():
+                logger.warning("null_values_found", column=col)
+                return False
+
+        # Check numeric columns are valid
+        numeric_cols = ["open", "high", "low", "close", "volume"]
+        for col in numeric_cols:
+            if not pd.api.types.is_numeric_dtype(df[col]):
+                logger.warning("non_numeric_column", column=col)
+                return False
+
+        return True
+
+    def resample(
+        self,
+        df: pd.DataFrame,
+        target_timeframe: str,
+    ) -> pd.DataFrame:
+        """
+        Resample OHLCV data to a different timeframe.
+
+        Args:
+            df: Source DataFrame
+            target_timeframe: Target timeframe (e.g., "1h", "4h", "1d")
+
+        Returns:
+            Resampled DataFrame
+        """
+        # Set datetime as index
+        df = df.set_index("datetime")
+
+        # Resample
+        resampled = df.resample(target_timeframe).agg(
+            {
+                "open": "first",
+                "high": "max",
+                "low": "min",
+                "close": "last",
+                "volume": "sum",
+            }
+        )
+
+        # Drop any rows with NaN (incomplete candles)
+        resampled = resampled.dropna()
+
+        # Reset index
+        resampled = resampled.reset_index()
+
+        return resampled

--- a/keryxflow/backtester/engine.py
+++ b/keryxflow/backtester/engine.py
@@ -1,0 +1,478 @@
+"""Backtesting engine for strategy simulation."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from keryxflow.aegis.quant import QuantEngine, get_quant_engine
+from keryxflow.aegis.risk import OrderRequest, RiskManager, get_risk_manager
+from keryxflow.config import get_settings
+from keryxflow.core.logging import get_logger
+from keryxflow.core.models import RiskProfile
+from keryxflow.oracle.signals import SignalGenerator, SignalType, get_signal_generator
+
+if TYPE_CHECKING:
+    from keryxflow.backtester.report import BacktestResult
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class BacktestTrade:
+    """A trade executed during backtesting."""
+
+    symbol: str
+    side: str  # "buy" or "sell"
+    quantity: float
+    entry_price: float
+    entry_time: datetime
+    exit_price: float | None = None
+    exit_time: datetime | None = None
+    stop_loss: float | None = None
+    take_profit: float | None = None
+    pnl: float = 0.0
+    pnl_percentage: float = 0.0
+    exit_reason: str | None = None  # "stop_loss", "take_profit", "signal", "end"
+
+    @property
+    def is_closed(self) -> bool:
+        """Check if trade is closed."""
+        return self.exit_price is not None
+
+    @property
+    def is_winner(self) -> bool:
+        """Check if trade is a winner."""
+        return self.pnl > 0
+
+
+@dataclass
+class BacktestPosition:
+    """An open position during backtesting."""
+
+    symbol: str
+    side: str
+    quantity: float
+    entry_price: float
+    entry_time: datetime
+    stop_loss: float | None = None
+    take_profit: float | None = None
+    current_price: float = 0.0
+
+    @property
+    def unrealized_pnl(self) -> float:
+        """Calculate unrealized PnL."""
+        if self.side == "buy":
+            return (self.current_price - self.entry_price) * self.quantity
+        else:
+            return (self.entry_price - self.current_price) * self.quantity
+
+    @property
+    def unrealized_pnl_percentage(self) -> float:
+        """Calculate unrealized PnL percentage."""
+        if self.entry_price == 0:
+            return 0.0
+        if self.side == "buy":
+            return (self.current_price - self.entry_price) / self.entry_price * 100
+        else:
+            return (self.entry_price - self.current_price) / self.entry_price * 100
+
+
+@dataclass
+class BacktestEngine:
+    """Backtesting engine that simulates trading with historical data."""
+
+    initial_balance: float = 10000.0
+    risk_profile: RiskProfile = RiskProfile.BALANCED
+    slippage: float = 0.001  # 0.1%
+    commission: float = 0.001  # 0.1% per trade
+    min_candles: int = 50  # Minimum candles for analysis
+
+    # Components (initialized in __post_init__)
+    signal_gen: SignalGenerator = field(init=False)
+    risk_manager: RiskManager = field(init=False)
+    quant: QuantEngine = field(init=False)
+
+    # State
+    balance: float = field(init=False)
+    positions: dict[str, BacktestPosition] = field(default_factory=dict)
+    trades: list[BacktestTrade] = field(default_factory=list)
+    equity_curve: list[float] = field(default_factory=list)
+    _current_time: datetime = field(init=False, default=None)
+
+    def __post_init__(self):
+        """Initialize components after dataclass init."""
+        self.balance = self.initial_balance
+        self.signal_gen = get_signal_generator()
+        self.risk_manager = get_risk_manager(
+            risk_profile=self.risk_profile,
+            initial_balance=self.initial_balance,
+        )
+        self.quant = get_quant_engine()
+        self.settings = get_settings()
+
+    async def run(
+        self,
+        data: dict[str, pd.DataFrame],
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> "BacktestResult":
+        """
+        Run backtest on historical data.
+
+        Args:
+            data: Dict of {symbol: OHLCV DataFrame}
+            start: Start datetime (optional, uses data start if None)
+            end: End datetime (optional, uses data end if None)
+
+        Returns:
+            BacktestResult with performance metrics
+        """
+
+        # Reset state
+        self.balance = self.initial_balance
+        self.positions = {}
+        self.trades = []
+        self.equity_curve = [self.initial_balance]
+
+        # Get all timestamps across all symbols
+        all_timestamps = set()
+        for df in data.values():
+            all_timestamps.update(df["datetime"].tolist())
+
+        timestamps = sorted(all_timestamps)
+
+        # Filter by start/end
+        if start:
+            timestamps = [t for t in timestamps if t >= start]
+        if end:
+            timestamps = [t for t in timestamps if t <= end]
+
+        if not timestamps:
+            raise ValueError("No data in specified range")
+
+        logger.info(
+            "backtest_starting",
+            symbols=list(data.keys()),
+            start=timestamps[0].isoformat(),
+            end=timestamps[-1].isoformat(),
+            candles=len(timestamps),
+        )
+
+        # Process each timestamp
+        for timestamp in timestamps:
+            self._current_time = timestamp
+
+            for symbol, df in data.items():
+                # Get data up to current timestamp
+                mask = df["datetime"] <= timestamp
+                history = df[mask]
+
+                if len(history) < self.min_candles:
+                    continue
+
+                current_candle = history.iloc[-1]
+                await self._process_candle(symbol, current_candle, history)
+
+            # Update equity curve
+            total_equity = self._calculate_equity()
+            self.equity_curve.append(total_equity)
+
+            # Update risk manager balance
+            self.risk_manager.update_balance(total_equity)
+
+        # Close any remaining positions at end
+        for symbol in list(self.positions.keys()):
+            last_price = data[symbol].iloc[-1]["close"]
+            self._close_position(symbol, last_price, "end")
+
+        # Calculate final metrics
+        return self._calculate_result()
+
+    async def _process_candle(
+        self,
+        symbol: str,
+        candle: pd.Series,
+        history: pd.DataFrame,
+    ) -> None:
+        """Process a single candle."""
+        current_price = candle["close"]
+        high = candle["high"]
+        low = candle["low"]
+
+        # Update position price if exists
+        if symbol in self.positions:
+            self.positions[symbol].current_price = current_price
+
+            # Check stops
+            self._check_stops(symbol, high, low)
+
+            # If position was closed by stop, return
+            if symbol not in self.positions:
+                return
+
+        # Generate signal (without LLM/news for speed)
+        try:
+            signal = await self.signal_gen.generate_signal(
+                symbol=symbol,
+                ohlcv=history,
+                current_price=current_price,
+                include_news=False,
+                include_llm=False,
+            )
+        except Exception as e:
+            logger.warning("signal_generation_failed", symbol=symbol, error=str(e))
+            return
+
+        # Process actionable signals
+        if not signal.is_actionable:
+            return
+
+        # Determine side
+        if signal.signal_type == SignalType.LONG:
+            side = "buy"
+        elif signal.signal_type == SignalType.SHORT:
+            side = "sell"
+        elif signal.signal_type in (SignalType.CLOSE_LONG, SignalType.CLOSE_SHORT):
+            # Close existing position
+            if symbol in self.positions:
+                self._close_position(symbol, current_price, "signal")
+            return
+        else:
+            return
+
+        # Skip if already in position
+        if symbol in self.positions:
+            return
+
+        # Skip if no stop loss
+        if not signal.stop_loss:
+            return
+
+        # Calculate position size
+        quantity = self.risk_manager.calculate_safe_position_size(
+            symbol=symbol,
+            entry_price=signal.entry_price or current_price,
+            stop_loss=signal.stop_loss,
+            balance=self.balance,
+        )
+
+        if quantity <= 0:
+            return
+
+        # Create order request
+        order = OrderRequest(
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            entry_price=signal.entry_price or current_price,
+            stop_loss=signal.stop_loss,
+            take_profit=signal.take_profit,
+        )
+
+        # Get approval from risk manager
+        approval = self.risk_manager.approve_order(order, self.balance)
+
+        if not approval.approved:
+            logger.debug(
+                "order_rejected",
+                symbol=symbol,
+                reason=approval.reason.value if approval.reason else "unknown",
+            )
+            return
+
+        # Execute order
+        self._execute_order(order)
+
+    def _check_stops(self, symbol: str, high: float, low: float) -> None:
+        """Check if stops are hit."""
+        if symbol not in self.positions:
+            return
+
+        position = self.positions[symbol]
+
+        # Check stop loss
+        if position.stop_loss and (
+            (position.side == "buy" and low <= position.stop_loss)
+            or (position.side == "sell" and high >= position.stop_loss)
+        ):
+            self._close_position(symbol, position.stop_loss, "stop_loss")
+            return
+
+        # Check take profit
+        if position.take_profit and (
+            (position.side == "buy" and high >= position.take_profit)
+            or (position.side == "sell" and low <= position.take_profit)
+        ):
+            self._close_position(symbol, position.take_profit, "take_profit")
+            return
+
+    def _execute_order(self, order: OrderRequest) -> None:
+        """Execute an order (open position)."""
+        # Apply slippage
+        if order.side == "buy":
+            fill_price = order.entry_price * (1 + self.slippage)
+        else:
+            fill_price = order.entry_price * (1 - self.slippage)
+
+        # Calculate cost with commission
+        cost = order.quantity * fill_price
+        commission = cost * self.commission
+
+        # Deduct from balance
+        self.balance -= (cost + commission)
+
+        # Create position
+        position = BacktestPosition(
+            symbol=order.symbol,
+            side=order.side,
+            quantity=order.quantity,
+            entry_price=fill_price,
+            entry_time=self._current_time,
+            stop_loss=order.stop_loss,
+            take_profit=order.take_profit,
+            current_price=fill_price,
+        )
+
+        self.positions[order.symbol] = position
+
+        # Update risk manager position count
+        self.risk_manager.set_open_positions(len(self.positions))
+
+        logger.debug(
+            "position_opened",
+            symbol=order.symbol,
+            side=order.side,
+            quantity=order.quantity,
+            price=fill_price,
+        )
+
+    def _close_position(self, symbol: str, exit_price: float, reason: str) -> None:
+        """Close a position."""
+        if symbol not in self.positions:
+            return
+
+        position = self.positions[symbol]
+
+        # Apply slippage on exit
+        if position.side == "buy":
+            fill_price = exit_price * (1 - self.slippage)
+        else:
+            fill_price = exit_price * (1 + self.slippage)
+
+        # Calculate PnL
+        if position.side == "buy":
+            pnl = (fill_price - position.entry_price) * position.quantity
+        else:
+            pnl = (position.entry_price - fill_price) * position.quantity
+
+        # Deduct commission
+        commission = position.quantity * fill_price * self.commission
+        pnl -= commission
+
+        # Calculate percentage
+        entry_value = position.entry_price * position.quantity
+        pnl_percentage = (pnl / entry_value) * 100 if entry_value > 0 else 0
+
+        # Add to balance
+        exit_value = position.quantity * fill_price
+        self.balance += exit_value
+
+        # Create trade record
+        trade = BacktestTrade(
+            symbol=symbol,
+            side=position.side,
+            quantity=position.quantity,
+            entry_price=position.entry_price,
+            entry_time=position.entry_time,
+            exit_price=fill_price,
+            exit_time=self._current_time,
+            stop_loss=position.stop_loss,
+            take_profit=position.take_profit,
+            pnl=pnl,
+            pnl_percentage=pnl_percentage,
+            exit_reason=reason,
+        )
+
+        self.trades.append(trade)
+
+        # Remove position
+        del self.positions[symbol]
+
+        # Update risk manager
+        self.risk_manager.set_open_positions(len(self.positions))
+        self.risk_manager.update_daily_pnl(pnl)
+
+        logger.debug(
+            "position_closed",
+            symbol=symbol,
+            pnl=pnl,
+            reason=reason,
+        )
+
+    def _calculate_equity(self) -> float:
+        """Calculate total equity (balance + unrealized PnL)."""
+        unrealized = sum(pos.unrealized_pnl for pos in self.positions.values())
+        return self.balance + unrealized
+
+    def _calculate_result(self) -> "BacktestResult":
+        """Calculate backtest result with metrics."""
+        from keryxflow.backtester.report import BacktestResult
+
+        final_balance = self._calculate_equity()
+        total_return = (final_balance - self.initial_balance) / self.initial_balance
+
+        # Trade statistics
+        total_trades = len(self.trades)
+        winning_trades = sum(1 for t in self.trades if t.is_winner)
+        losing_trades = total_trades - winning_trades
+        win_rate = winning_trades / total_trades if total_trades > 0 else 0
+
+        # Average win/loss
+        wins = [t.pnl for t in self.trades if t.is_winner]
+        losses = [abs(t.pnl) for t in self.trades if not t.is_winner]
+        avg_win = sum(wins) / len(wins) if wins else 0
+        avg_loss = sum(losses) / len(losses) if losses else 0
+
+        # Expectancy
+        expectancy = self.quant.calculate_expectancy(win_rate, avg_win, avg_loss)
+
+        # Profit factor
+        gross_profit = sum(wins)
+        gross_loss = sum(losses)
+        profit_factor = gross_profit / gross_loss if gross_loss > 0 else float("inf")
+
+        # Drawdown
+        current_dd, max_dd, max_dd_duration = self.quant.calculate_drawdown(
+            self.equity_curve
+        )
+
+        # Sharpe ratio (using daily returns approximation)
+        returns = []
+        for i in range(1, len(self.equity_curve)):
+            ret = (self.equity_curve[i] - self.equity_curve[i - 1]) / self.equity_curve[
+                i - 1
+            ]
+            returns.append(ret)
+
+        sharpe = self.quant.calculate_sharpe_ratio(returns) if returns else 0
+
+        return BacktestResult(
+            initial_balance=self.initial_balance,
+            final_balance=final_balance,
+            total_return=total_return,
+            total_trades=total_trades,
+            winning_trades=winning_trades,
+            losing_trades=losing_trades,
+            win_rate=win_rate,
+            avg_win=avg_win,
+            avg_loss=avg_loss,
+            expectancy=expectancy,
+            profit_factor=profit_factor,
+            max_drawdown=max_dd,
+            max_drawdown_duration=max_dd_duration,
+            sharpe_ratio=sharpe,
+            trades=self.trades,
+            equity_curve=self.equity_curve,
+        )

--- a/keryxflow/backtester/report.py
+++ b/keryxflow/backtester/report.py
@@ -1,0 +1,293 @@
+"""Backtesting report and metrics."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from keryxflow.backtester.engine import BacktestTrade
+
+
+@dataclass
+class BacktestResult:
+    """Result of a backtest run."""
+
+    # Performance
+    initial_balance: float
+    final_balance: float
+    total_return: float  # as decimal (0.15 = 15%)
+
+    # Trade statistics
+    total_trades: int
+    winning_trades: int
+    losing_trades: int
+    win_rate: float  # as decimal
+
+    # Trade metrics
+    avg_win: float
+    avg_loss: float
+    expectancy: float
+    profit_factor: float
+
+    # Risk metrics
+    max_drawdown: float  # as decimal
+    max_drawdown_duration: int  # in periods
+    sharpe_ratio: float
+
+    # Raw data
+    trades: list["BacktestTrade"] = field(default_factory=list)
+    equity_curve: list[float] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "performance": {
+                "initial_balance": self.initial_balance,
+                "final_balance": self.final_balance,
+                "total_return": self.total_return,
+                "total_return_pct": f"{self.total_return * 100:.2f}%",
+            },
+            "trades": {
+                "total": self.total_trades,
+                "winning": self.winning_trades,
+                "losing": self.losing_trades,
+                "win_rate": self.win_rate,
+                "win_rate_pct": f"{self.win_rate * 100:.1f}%",
+            },
+            "metrics": {
+                "avg_win": self.avg_win,
+                "avg_loss": self.avg_loss,
+                "expectancy": self.expectancy,
+                "profit_factor": self.profit_factor,
+            },
+            "risk": {
+                "max_drawdown": self.max_drawdown,
+                "max_drawdown_pct": f"{self.max_drawdown * 100:.2f}%",
+                "max_drawdown_duration": self.max_drawdown_duration,
+                "sharpe_ratio": self.sharpe_ratio,
+            },
+        }
+
+
+class BacktestReporter:
+    """Generates reports from backtest results."""
+
+    @staticmethod
+    def print_summary(result: BacktestResult) -> str:
+        """
+        Generate a formatted summary report.
+
+        Returns:
+            Formatted string for terminal output
+        """
+        pnl = result.final_balance - result.initial_balance
+        pnl_sign = "+" if pnl >= 0 else ""
+
+        lines = [
+            "",
+            "=" * 50,
+            "             BACKTEST REPORT",
+            "=" * 50,
+            "",
+            "PERFORMANCE",
+            "-" * 50,
+            f"  Initial Balance:    ${result.initial_balance:,.2f}",
+            f"  Final Balance:      ${result.final_balance:,.2f}",
+            f"  Total Return:       {pnl_sign}{result.total_return * 100:.2f}%",
+            f"  Net P&L:            {pnl_sign}${pnl:,.2f}",
+            "",
+            "TRADES",
+            "-" * 50,
+            f"  Total Trades:       {result.total_trades}",
+            f"  Winning Trades:     {result.winning_trades}",
+            f"  Losing Trades:      {result.losing_trades}",
+            f"  Win Rate:           {result.win_rate * 100:.1f}%",
+            "",
+            "METRICS",
+            "-" * 50,
+            f"  Avg Win:            ${result.avg_win:,.2f}",
+            f"  Avg Loss:           ${result.avg_loss:,.2f}",
+            f"  Expectancy:         ${result.expectancy:,.2f}/trade",
+            f"  Profit Factor:      {result.profit_factor:.2f}",
+            "",
+            "RISK",
+            "-" * 50,
+            f"  Max Drawdown:       {result.max_drawdown * 100:.2f}%",
+            f"  DD Duration:        {result.max_drawdown_duration} periods",
+            f"  Sharpe Ratio:       {result.sharpe_ratio:.2f}",
+            "",
+            "=" * 50,
+        ]
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def save_trades_csv(result: BacktestResult, path: str | Path) -> None:
+        """
+        Save trades to CSV file.
+
+        Args:
+            result: Backtest result
+            path: Output file path
+        """
+        import csv
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(path, "w", newline="") as f:
+            writer = csv.writer(f)
+
+            # Header
+            writer.writerow(
+                [
+                    "symbol",
+                    "side",
+                    "quantity",
+                    "entry_price",
+                    "entry_time",
+                    "exit_price",
+                    "exit_time",
+                    "stop_loss",
+                    "take_profit",
+                    "pnl",
+                    "pnl_pct",
+                    "exit_reason",
+                ]
+            )
+
+            # Trades
+            for trade in result.trades:
+                writer.writerow(
+                    [
+                        trade.symbol,
+                        trade.side,
+                        trade.quantity,
+                        trade.entry_price,
+                        trade.entry_time.isoformat() if trade.entry_time else "",
+                        trade.exit_price,
+                        trade.exit_time.isoformat() if trade.exit_time else "",
+                        trade.stop_loss,
+                        trade.take_profit,
+                        trade.pnl,
+                        trade.pnl_percentage,
+                        trade.exit_reason,
+                    ]
+                )
+
+    @staticmethod
+    def save_equity_csv(result: BacktestResult, path: str | Path) -> None:
+        """
+        Save equity curve to CSV file.
+
+        Args:
+            result: Backtest result
+            path: Output file path
+        """
+        import csv
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["period", "equity"])
+
+            for i, equity in enumerate(result.equity_curve):
+                writer.writerow([i, equity])
+
+    @staticmethod
+    def plot_equity_ascii(result: BacktestResult, width: int = 60, height: int = 15) -> str:
+        """
+        Generate ASCII art equity curve.
+
+        Args:
+            result: Backtest result
+            width: Chart width in characters
+            height: Chart height in lines
+
+        Returns:
+            ASCII chart string
+        """
+        if not result.equity_curve:
+            return "No equity data"
+
+        curve = result.equity_curve
+
+        # Downsample if needed
+        if len(curve) > width:
+            step = len(curve) / width
+            curve = [curve[int(i * step)] for i in range(width)]
+
+        min_val = min(curve)
+        max_val = max(curve)
+        val_range = max_val - min_val
+
+        if val_range == 0:
+            val_range = 1
+
+        # Build chart
+        lines = []
+
+        # Header
+        lines.append(f"  ${max_val:,.0f} ┤")
+
+        # Chart body
+        for row in range(height - 2):
+            threshold = max_val - (row + 1) * (val_range / (height - 1))
+            line = "        │"
+
+            for val in curve:
+                if val >= threshold:
+                    line += "█"
+                else:
+                    line += " "
+
+            lines.append(line)
+
+        # Footer
+        lines.append(f"  ${min_val:,.0f} ┼" + "─" * len(curve))
+        lines.append("        " + "└" + "─" * (len(curve) - 1) + "▶")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def format_trade_list(result: BacktestResult, limit: int = 10) -> str:
+        """
+        Format recent trades as a table.
+
+        Args:
+            result: Backtest result
+            limit: Maximum trades to show
+
+        Returns:
+            Formatted string
+        """
+        if not result.trades:
+            return "No trades"
+
+        trades = result.trades[-limit:]
+
+        lines = [
+            "",
+            "RECENT TRADES",
+            "-" * 70,
+            f"{'Symbol':<12} {'Side':<6} {'Entry':>10} {'Exit':>10} {'PnL':>12} {'Reason':<12}",
+            "-" * 70,
+        ]
+
+        for trade in trades:
+            pnl_str = f"${trade.pnl:+,.2f}"
+
+            lines.append(
+                f"{trade.symbol:<12} "
+                f"{trade.side.upper():<6} "
+                f"${trade.entry_price:>9,.2f} "
+                f"${trade.exit_price or 0:>9,.2f} "
+                f"{pnl_str:>12} "
+                f"{trade.exit_reason or '':<12}"
+            )
+
+        lines.append("-" * 70)
+
+        return "\n".join(lines)

--- a/keryxflow/backtester/runner.py
+++ b/keryxflow/backtester/runner.py
@@ -1,0 +1,274 @@
+"""CLI runner for backtesting."""
+
+import argparse
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+
+from keryxflow.backtester.data import DataLoader
+from keryxflow.backtester.engine import BacktestEngine
+from keryxflow.backtester.report import BacktestReporter, BacktestResult
+from keryxflow.core.logging import get_logger
+from keryxflow.core.models import RiskProfile
+from keryxflow.exchange.client import ExchangeClient
+
+logger = get_logger(__name__)
+
+
+async def run_backtest(
+    symbols: list[str],
+    start: datetime,
+    end: datetime,
+    initial_balance: float = 10000.0,
+    risk_profile: RiskProfile = RiskProfile.BALANCED,
+    timeframe: str = "1h",
+    data_source: str | None = None,
+    slippage: float = 0.001,
+    commission: float = 0.001,
+) -> BacktestResult:
+    """
+    Run a complete backtest.
+
+    Args:
+        symbols: List of trading pairs
+        start: Start datetime
+        end: End datetime
+        initial_balance: Starting balance
+        risk_profile: Risk profile to use
+        timeframe: Candle timeframe
+        data_source: Path to CSV file (if None, uses exchange)
+        slippage: Slippage percentage
+        commission: Commission percentage
+
+    Returns:
+        BacktestResult with metrics
+    """
+    # Load data
+    if data_source and Path(data_source).exists():
+        # Load from CSV
+        loader = DataLoader()
+        data = {}
+        for symbol in symbols:
+            # Assume CSV is named like BTC_USDT.csv
+            csv_name = symbol.replace("/", "_") + ".csv"
+            csv_path = Path(data_source) / csv_name
+            if csv_path.exists():
+                data[symbol] = loader.load_from_csv(csv_path)
+            else:
+                logger.warning("csv_not_found", symbol=symbol, path=str(csv_path))
+    else:
+        # Load from exchange
+        exchange = ExchangeClient()
+        await exchange.connect()
+
+        try:
+            loader = DataLoader(exchange_client=exchange)
+            data = {}
+
+            for symbol in symbols:
+                df = await loader.load_from_exchange(
+                    symbol=symbol,
+                    start=start,
+                    end=end,
+                    timeframe=timeframe,
+                )
+                data[symbol] = df
+        finally:
+            await exchange.close()
+
+    if not data:
+        raise ValueError("No data loaded for any symbol")
+
+    # Create and run backtest engine
+    engine = BacktestEngine(
+        initial_balance=initial_balance,
+        risk_profile=risk_profile,
+        slippage=slippage,
+        commission=commission,
+    )
+
+    result = await engine.run(data, start=start, end=end)
+
+    return result
+
+
+def parse_date(date_str: str) -> datetime:
+    """Parse date string to datetime."""
+    return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=UTC)
+
+
+def parse_risk_profile(profile_str: str) -> RiskProfile:
+    """Parse risk profile string."""
+    profiles = {
+        "conservative": RiskProfile.CONSERVATIVE,
+        "balanced": RiskProfile.BALANCED,
+        "aggressive": RiskProfile.AGGRESSIVE,
+    }
+    return profiles.get(profile_str.lower(), RiskProfile.BALANCED)
+
+
+def main() -> None:
+    """CLI entry point for backtesting."""
+    parser = argparse.ArgumentParser(
+        description="KeryxFlow Backtesting Engine",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Backtest BTC/USDT for 2024
+  %(prog)s --symbol BTC/USDT --start 2024-01-01 --end 2024-06-30
+
+  # Backtest with custom settings
+  %(prog)s --symbol BTC/USDT ETH/USDT --start 2024-01-01 --end 2024-06-30 \\
+           --balance 50000 --profile aggressive --timeframe 4h
+
+  # Backtest from CSV files
+  %(prog)s --symbol BTC/USDT --start 2024-01-01 --end 2024-12-31 \\
+           --data ./historical_data/
+        """,
+    )
+
+    parser.add_argument(
+        "--symbol",
+        "-s",
+        nargs="+",
+        required=True,
+        help="Trading pairs (e.g., BTC/USDT ETH/USDT)",
+    )
+
+    parser.add_argument(
+        "--start",
+        required=True,
+        help="Start date (YYYY-MM-DD)",
+    )
+
+    parser.add_argument(
+        "--end",
+        required=True,
+        help="End date (YYYY-MM-DD)",
+    )
+
+    parser.add_argument(
+        "--balance",
+        "-b",
+        type=float,
+        default=10000.0,
+        help="Initial balance (default: 10000)",
+    )
+
+    parser.add_argument(
+        "--profile",
+        "-p",
+        choices=["conservative", "balanced", "aggressive"],
+        default="balanced",
+        help="Risk profile (default: balanced)",
+    )
+
+    parser.add_argument(
+        "--timeframe",
+        "-t",
+        default="1h",
+        help="Candle timeframe (default: 1h)",
+    )
+
+    parser.add_argument(
+        "--data",
+        "-d",
+        help="Path to directory with CSV files (optional)",
+    )
+
+    parser.add_argument(
+        "--slippage",
+        type=float,
+        default=0.001,
+        help="Slippage percentage (default: 0.001 = 0.1%%)",
+    )
+
+    parser.add_argument(
+        "--commission",
+        type=float,
+        default=0.001,
+        help="Commission percentage (default: 0.001 = 0.1%%)",
+    )
+
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Output directory for CSV reports",
+    )
+
+    parser.add_argument(
+        "--chart",
+        action="store_true",
+        help="Show ASCII equity chart",
+    )
+
+    parser.add_argument(
+        "--trades",
+        type=int,
+        default=0,
+        help="Show last N trades (default: 0 = none)",
+    )
+
+    args = parser.parse_args()
+
+    # Parse arguments
+    start = parse_date(args.start)
+    end = parse_date(args.end)
+    risk_profile = parse_risk_profile(args.profile)
+
+    print("\nKeryxFlow Backtest")
+    print(f"Symbols: {', '.join(args.symbol)}")
+    print(f"Period: {args.start} to {args.end}")
+    print(f"Timeframe: {args.timeframe}")
+    print(f"Risk Profile: {args.profile}")
+    print(f"Initial Balance: ${args.balance:,.2f}")
+    print("\nLoading data and running backtest...")
+
+    # Run backtest
+    try:
+        result = asyncio.run(
+            run_backtest(
+                symbols=args.symbol,
+                start=start,
+                end=end,
+                initial_balance=args.balance,
+                risk_profile=risk_profile,
+                timeframe=args.timeframe,
+                data_source=args.data,
+                slippage=args.slippage,
+                commission=args.commission,
+            )
+        )
+    except Exception as e:
+        print(f"\nError: {e}")
+        return
+
+    # Print summary
+    print(BacktestReporter.print_summary(result))
+
+    # Show chart if requested
+    if args.chart:
+        print("\nEQUITY CURVE")
+        print(BacktestReporter.plot_equity_ascii(result))
+
+    # Show trades if requested
+    if args.trades > 0:
+        print(BacktestReporter.format_trade_list(result, limit=args.trades))
+
+    # Save outputs if requested
+    if args.output:
+        output_dir = Path(args.output)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        trades_path = output_dir / "trades.csv"
+        equity_path = output_dir / "equity.csv"
+
+        BacktestReporter.save_trades_csv(result, trades_path)
+        BacktestReporter.save_equity_csv(result, equity_path)
+
+        print(f"\nSaved trades to: {trades_path}")
+        print(f"Saved equity curve to: {equity_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keryxflow"
-version = "0.6.0"
+version = "0.7.0"
 description = "A hybrid AI & quantitative trading engine for cryptocurrency markets"
 authors = ["KeryxFlow Contributors"]
 license = "MIT"
@@ -10,6 +10,7 @@ keywords = ["trading", "cryptocurrency", "bitcoin", "ai", "algorithmic-trading"]
 
 [tool.poetry.scripts]
 keryxflow = "keryxflow.main:run"
+keryxflow-backtest = "keryxflow.backtester.runner:main"
 
 [tool.poetry.dependencies]
 python = "^3.12"

--- a/tests/test_backtester/__init__.py
+++ b/tests/test_backtester/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for backtester module."""

--- a/tests/test_backtester/test_data.py
+++ b/tests/test_backtester/test_data.py
@@ -1,0 +1,168 @@
+"""Tests for backtester data loading."""
+
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from keryxflow.backtester.data import DataLoader
+
+
+class TestDataLoader:
+    """Tests for DataLoader."""
+
+    def test_init_without_exchange(self):
+        """Test initialization without exchange client."""
+        loader = DataLoader()
+        assert loader.exchange is None
+
+    def test_validate_data_valid(self):
+        """Test validation with valid data."""
+        loader = DataLoader()
+
+        df = pd.DataFrame(
+            {
+                "datetime": [datetime.now(UTC)],
+                "open": [100.0],
+                "high": [105.0],
+                "low": [95.0],
+                "close": [102.0],
+                "volume": [1000.0],
+            }
+        )
+
+        assert loader.validate_data(df) is True
+
+    def test_validate_data_missing_columns(self):
+        """Test validation with missing columns."""
+        loader = DataLoader()
+
+        df = pd.DataFrame(
+            {
+                "datetime": [datetime.now(UTC)],
+                "open": [100.0],
+                "close": [102.0],
+            }
+        )
+
+        assert loader.validate_data(df) is False
+
+    def test_validate_data_null_values(self):
+        """Test validation with null values."""
+        loader = DataLoader()
+
+        df = pd.DataFrame(
+            {
+                "datetime": [datetime.now(UTC), datetime.now(UTC)],
+                "open": [100.0, None],
+                "high": [105.0, 106.0],
+                "low": [95.0, 94.0],
+                "close": [102.0, 103.0],
+                "volume": [1000.0, 1100.0],
+            }
+        )
+
+        assert loader.validate_data(df) is False
+
+    def test_validate_data_non_numeric(self):
+        """Test validation with non-numeric data."""
+        loader = DataLoader()
+
+        df = pd.DataFrame(
+            {
+                "datetime": [datetime.now(UTC)],
+                "open": ["one hundred"],
+                "high": [105.0],
+                "low": [95.0],
+                "close": [102.0],
+                "volume": [1000.0],
+            }
+        )
+
+        assert loader.validate_data(df) is False
+
+    def test_load_from_csv(self):
+        """Test loading from CSV file."""
+        loader = DataLoader()
+
+        # Create temp CSV
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write("datetime,open,high,low,close,volume\n")
+            f.write("2024-01-01 00:00:00,100.0,105.0,95.0,102.0,1000.0\n")
+            f.write("2024-01-01 01:00:00,102.0,108.0,100.0,106.0,1200.0\n")
+            temp_path = f.name
+
+        try:
+            df = loader.load_from_csv(temp_path)
+
+            assert len(df) == 2
+            assert "datetime" in df.columns
+            assert "open" in df.columns
+            assert "close" in df.columns
+            assert df["open"].iloc[0] == 100.0
+        finally:
+            Path(temp_path).unlink()
+
+    def test_load_from_csv_not_found(self):
+        """Test loading from non-existent CSV."""
+        loader = DataLoader()
+
+        with pytest.raises(FileNotFoundError):
+            loader.load_from_csv("/nonexistent/path.csv")
+
+    def test_load_from_csv_invalid_format(self):
+        """Test loading from invalid CSV."""
+        loader = DataLoader()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            f.write("col1,col2\n")
+            f.write("a,b\n")
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ValueError):
+                loader.load_from_csv(temp_path)
+        finally:
+            Path(temp_path).unlink()
+
+    def test_resample(self):
+        """Test resampling to different timeframe."""
+        loader = DataLoader()
+
+        # Create hourly data
+        dates = pd.date_range("2024-01-01", periods=24, freq="h", tz=UTC)
+        df = pd.DataFrame(
+            {
+                "datetime": dates,
+                "open": [100 + i for i in range(24)],
+                "high": [105 + i for i in range(24)],
+                "low": [95 + i for i in range(24)],
+                "close": [102 + i for i in range(24)],
+                "volume": [1000 + i * 10 for i in range(24)],
+            }
+        )
+
+        # Resample to 4h
+        resampled = loader.resample(df, "4h")
+
+        assert len(resampled) == 6  # 24h / 4h = 6 candles
+        assert resampled["open"].iloc[0] == 100  # First open
+        assert resampled["close"].iloc[0] == 105  # Last close of first 4h
+
+
+class TestDataLoaderExchange:
+    """Tests for exchange data loading (requires mocking)."""
+
+    @pytest.mark.asyncio
+    async def test_load_from_exchange_no_client(self):
+        """Test loading without exchange client raises error."""
+        loader = DataLoader()
+
+        with pytest.raises(ValueError, match="Exchange client required"):
+            await loader.load_from_exchange(
+                symbol="BTC/USDT",
+                start=datetime(2024, 1, 1, tzinfo=UTC),
+                end=datetime(2024, 1, 2, tzinfo=UTC),
+            )

--- a/tests/test_backtester/test_engine.py
+++ b/tests/test_backtester/test_engine.py
@@ -1,0 +1,393 @@
+"""Tests for backtester engine."""
+
+from datetime import UTC, datetime
+
+import pandas as pd
+import pytest
+
+from keryxflow.backtester.engine import (
+    BacktestEngine,
+    BacktestPosition,
+    BacktestTrade,
+)
+from keryxflow.core.models import RiskProfile
+
+
+class TestBacktestTrade:
+    """Tests for BacktestTrade dataclass."""
+
+    def test_is_closed_false(self):
+        """Test trade is not closed without exit price."""
+        trade = BacktestTrade(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+        )
+
+        assert trade.is_closed is False
+
+    def test_is_closed_true(self):
+        """Test trade is closed with exit price."""
+        trade = BacktestTrade(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            exit_price=51000.0,
+            exit_time=datetime.now(UTC),
+        )
+
+        assert trade.is_closed is True
+
+    def test_is_winner_true(self):
+        """Test winning trade."""
+        trade = BacktestTrade(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            exit_price=51000.0,
+            pnl=100.0,
+        )
+
+        assert trade.is_winner is True
+
+    def test_is_winner_false(self):
+        """Test losing trade."""
+        trade = BacktestTrade(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            exit_price=49000.0,
+            pnl=-100.0,
+        )
+
+        assert trade.is_winner is False
+
+
+class TestBacktestPosition:
+    """Tests for BacktestPosition dataclass."""
+
+    def test_unrealized_pnl_long_profit(self):
+        """Test unrealized PnL for profitable long."""
+        position = BacktestPosition(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            current_price=51000.0,
+        )
+
+        assert position.unrealized_pnl == 100.0  # (51000 - 50000) * 0.1
+
+    def test_unrealized_pnl_long_loss(self):
+        """Test unrealized PnL for losing long."""
+        position = BacktestPosition(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            current_price=49000.0,
+        )
+
+        assert position.unrealized_pnl == -100.0
+
+    def test_unrealized_pnl_short_profit(self):
+        """Test unrealized PnL for profitable short."""
+        position = BacktestPosition(
+            symbol="BTC/USDT",
+            side="sell",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            current_price=49000.0,
+        )
+
+        assert position.unrealized_pnl == 100.0  # (50000 - 49000) * 0.1
+
+    def test_unrealized_pnl_short_loss(self):
+        """Test unrealized PnL for losing short."""
+        position = BacktestPosition(
+            symbol="BTC/USDT",
+            side="sell",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            current_price=51000.0,
+        )
+
+        assert position.unrealized_pnl == -100.0
+
+    def test_unrealized_pnl_percentage(self):
+        """Test unrealized PnL percentage."""
+        position = BacktestPosition(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            current_price=55000.0,
+        )
+
+        assert position.unrealized_pnl_percentage == 10.0  # 10% gain
+
+
+class TestBacktestEngineInit:
+    """Tests for BacktestEngine initialization."""
+
+    def test_default_init(self):
+        """Test default initialization."""
+        engine = BacktestEngine()
+
+        assert engine.initial_balance == 10000.0
+        assert engine.risk_profile == RiskProfile.BALANCED
+        assert engine.slippage == 0.001
+        assert engine.commission == 0.001
+        assert engine.min_candles == 50
+        assert engine.balance == 10000.0
+        assert engine.positions == {}
+        assert engine.trades == []
+
+    def test_custom_init(self):
+        """Test custom initialization."""
+        engine = BacktestEngine(
+            initial_balance=50000.0,
+            risk_profile=RiskProfile.AGGRESSIVE,
+            slippage=0.002,
+            commission=0.0005,
+        )
+
+        assert engine.initial_balance == 50000.0
+        assert engine.risk_profile == RiskProfile.AGGRESSIVE
+        assert engine.slippage == 0.002
+        assert engine.commission == 0.0005
+
+    def test_components_initialized(self):
+        """Test that components are initialized."""
+        engine = BacktestEngine()
+
+        assert engine.signal_gen is not None
+        assert engine.risk_manager is not None
+        assert engine.quant is not None
+
+
+class TestBacktestEngineStops:
+    """Tests for stop loss/take profit checking."""
+
+    def test_check_stops_no_position(self):
+        """Test check_stops with no position."""
+        engine = BacktestEngine()
+        engine._check_stops("BTC/USDT", 51000.0, 49000.0)
+
+        # Should not raise, just return
+        assert "BTC/USDT" not in engine.positions
+
+    def test_check_stops_long_stop_hit(self):
+        """Test stop loss hit on long position."""
+        engine = BacktestEngine()
+        engine._current_time = datetime.now(UTC)
+
+        # Add position
+        engine.positions["BTC/USDT"] = BacktestPosition(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            stop_loss=49000.0,
+            current_price=50000.0,
+        )
+
+        # Check stops with low below stop
+        engine._check_stops("BTC/USDT", 50500.0, 48500.0)
+
+        # Position should be closed
+        assert "BTC/USDT" not in engine.positions
+        assert len(engine.trades) == 1
+        assert engine.trades[0].exit_reason == "stop_loss"
+
+    def test_check_stops_long_take_profit_hit(self):
+        """Test take profit hit on long position."""
+        engine = BacktestEngine()
+        engine._current_time = datetime.now(UTC)
+
+        # Add position
+        engine.positions["BTC/USDT"] = BacktestPosition(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            take_profit=52000.0,
+            current_price=50000.0,
+        )
+
+        # Check stops with high above take profit
+        engine._check_stops("BTC/USDT", 52500.0, 50000.0)
+
+        # Position should be closed
+        assert "BTC/USDT" not in engine.positions
+        assert len(engine.trades) == 1
+        assert engine.trades[0].exit_reason == "take_profit"
+
+    def test_check_stops_short_stop_hit(self):
+        """Test stop loss hit on short position."""
+        engine = BacktestEngine()
+        engine._current_time = datetime.now(UTC)
+
+        # Add short position
+        engine.positions["BTC/USDT"] = BacktestPosition(
+            symbol="BTC/USDT",
+            side="sell",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            stop_loss=51000.0,
+            current_price=50000.0,
+        )
+
+        # Check stops with high above stop
+        engine._check_stops("BTC/USDT", 51500.0, 49500.0)
+
+        # Position should be closed
+        assert "BTC/USDT" not in engine.positions
+        assert len(engine.trades) == 1
+        assert engine.trades[0].exit_reason == "stop_loss"
+
+
+class TestBacktestEngineExecution:
+    """Tests for order execution."""
+
+    def test_calculate_equity_no_positions(self):
+        """Test equity calculation with no positions."""
+        engine = BacktestEngine(initial_balance=10000.0)
+
+        assert engine._calculate_equity() == 10000.0
+
+    def test_calculate_equity_with_position(self):
+        """Test equity calculation with open position."""
+        engine = BacktestEngine(initial_balance=10000.0)
+        engine.balance = 5000.0  # Used 5000 for position
+
+        engine.positions["BTC/USDT"] = BacktestPosition(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            entry_price=50000.0,
+            entry_time=datetime.now(UTC),
+            current_price=51000.0,  # 100 unrealized profit
+        )
+
+        equity = engine._calculate_equity()
+        assert equity == 5100.0  # 5000 + 100 unrealized
+
+
+class TestBacktestEngineRun:
+    """Integration tests for backtest run."""
+
+    @pytest.fixture
+    def sample_data(self):
+        """Create sample OHLCV data."""
+        # Create 100 candles of synthetic data
+        dates = pd.date_range("2024-01-01", periods=100, freq="h", tz=UTC)
+
+        # Simple trending data
+        base_price = 50000.0
+        prices = [base_price + (i * 50) for i in range(100)]
+
+        return {
+            "BTC/USDT": pd.DataFrame(
+                {
+                    "datetime": dates,
+                    "open": [p - 10 for p in prices],
+                    "high": [p + 50 for p in prices],
+                    "low": [p - 100 for p in prices],
+                    "close": prices,
+                    "volume": [1000.0] * 100,
+                }
+            )
+        }
+
+    @pytest.mark.asyncio
+    async def test_run_no_data_raises(self):
+        """Test run with no data raises error."""
+        engine = BacktestEngine()
+
+        with pytest.raises(ValueError):
+            await engine.run({})
+
+    @pytest.mark.asyncio
+    async def test_run_returns_result(self, sample_data):
+        """Test run returns BacktestResult."""
+        engine = BacktestEngine(initial_balance=10000.0, min_candles=20)
+
+        result = await engine.run(sample_data)
+
+        assert result is not None
+        assert result.initial_balance == 10000.0
+        assert result.final_balance >= 0
+        assert len(result.equity_curve) > 0
+
+    @pytest.mark.asyncio
+    async def test_run_equity_curve_starts_with_initial(self, sample_data):
+        """Test equity curve starts with initial balance."""
+        engine = BacktestEngine(initial_balance=10000.0, min_candles=20)
+
+        result = await engine.run(sample_data)
+
+        assert result.equity_curve[0] == 10000.0
+
+    @pytest.mark.asyncio
+    async def test_run_with_date_range(self, sample_data):
+        """Test run with date range filter."""
+        engine = BacktestEngine(initial_balance=10000.0, min_candles=20)
+
+        start = datetime(2024, 1, 2, tzinfo=UTC)
+        end = datetime(2024, 1, 3, tzinfo=UTC)
+
+        result = await engine.run(sample_data, start=start, end=end)
+
+        assert result is not None
+
+
+class TestBacktestResult:
+    """Tests for BacktestResult."""
+
+    def test_to_dict(self):
+        """Test to_dict conversion."""
+        from keryxflow.backtester.report import BacktestResult
+
+        result = BacktestResult(
+            initial_balance=10000.0,
+            final_balance=12000.0,
+            total_return=0.20,
+            total_trades=10,
+            winning_trades=6,
+            losing_trades=4,
+            win_rate=0.6,
+            avg_win=500.0,
+            avg_loss=200.0,
+            expectancy=220.0,
+            profit_factor=3.75,
+            max_drawdown=0.05,
+            max_drawdown_duration=10,
+            sharpe_ratio=1.5,
+            trades=[],
+            equity_curve=[10000.0, 12000.0],
+        )
+
+        d = result.to_dict()
+
+        assert d["performance"]["initial_balance"] == 10000.0
+        assert d["performance"]["final_balance"] == 12000.0
+        assert d["trades"]["total"] == 10
+        assert d["trades"]["win_rate"] == 0.6
+        assert d["risk"]["sharpe_ratio"] == 1.5


### PR DESCRIPTION
…se 7)

  - DataLoader: load OHLCV from Binance API or CSV files
  - BacktestEngine: simulate trading with historical data
  - BacktestResult: metrics (Sharpe, drawdown, win rate, expectancy)
  - BacktestReporter: formatted terminal output and CSV export
  - CLI runner: poetry run keryxflow-backtest

  Reuses existing components:
  - SignalGenerator (oracle)
  - RiskManager (aegis)
  - QuantEngine (aegis)