### PR TITLE
feat(agent): implement agent tool framework for AI-first trading (Pha…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,78 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ---
 
+## [0.13.0] - 2026-02-02
+
+### Added
+
+#### Agent Tools - AI Tool Framework (`keryxflow/agent/`)
+
+- **`tools.py`** - Agent tool framework
+  - `BaseTool` - Abstract base class for all agent tools
+  - `ToolParameter` - Parameter definition with type, description, validation
+  - `ToolResult` - Standardized result with success status and data
+  - `ToolCategory` - Categories: PERCEPTION, ANALYSIS, INTROSPECTION, EXECUTION
+  - `TradingToolkit` - Registry and manager for all tools
+  - `create_tool` - Decorator for creating tools from functions
+  - Anthropic Tool Use API compatible schema generation
+
+- **`perception_tools.py`** - Market data tools (7 tools)
+  - `get_current_price` - Get current price for a trading pair
+  - `get_ohlcv` - Get OHLCV candlestick data
+  - `get_order_book` - Get order book depth
+  - `get_portfolio_state` - Get portfolio with positions and risk metrics
+  - `get_balance` - Get account balances
+  - `get_positions` - Get all open positions
+  - `get_open_orders` - Get pending orders
+
+- **`analysis_tools.py`** - Analysis and memory tools (7 tools)
+  - `calculate_indicators` - Run technical analysis (RSI, MACD, etc.)
+  - `calculate_position_size` - Calculate safe position size
+  - `calculate_risk_reward` - Calculate R:R ratio for trade
+  - `calculate_stop_loss` - Calculate stop loss (fixed % or ATR)
+  - `get_trading_rules` - Get active rules from semantic memory
+  - `recall_similar_trades` - Recall similar trades from episodic memory
+  - `get_market_patterns` - Get matching patterns from memory
+
+- **`execution_tools.py`** - Order execution tools (6 tools, **GUARDED**)
+  - `place_order` - Place market or limit order (validates guardrails)
+  - `close_position` - Close an open position
+  - `set_stop_loss` - Update stop loss for position
+  - `set_take_profit` - Update take profit for position
+  - `cancel_order` - Cancel a pending order
+  - `close_all_positions` - Emergency close all (requires confirmation)
+
+- **`executor.py`** - Safe tool executor
+  - `ToolExecutor` - Wraps tool execution with guardrail validation
+  - Pre-execution guardrail checks for execution tools
+  - Rate limiting (max executions per minute)
+  - Execution statistics and history tracking
+  - Event publishing for tool lifecycle
+
+#### Tests (`tests/test_agent/`)
+
+- `test_tools.py` - Tool framework tests (25 tests)
+- `test_perception.py` - Perception tools tests (20 tests)
+- `test_analysis.py` - Analysis tools tests (24 tests)
+- `test_execution.py` - Execution tools tests (24 tests)
+- `test_executor.py` - Executor tests (16 tests)
+- Total: 109 new tests
+
+### Changed
+
+- Updated `tests/conftest.py` - Added singleton resets for agent module
+- Updated `CLAUDE.md` - Added agent tools documentation
+
+### Technical Details
+
+- **20 tools total** - All compatible with Anthropic Tool Use API
+- **Guarded execution** - Execution tools validate against guardrails before running
+- **Type-safe parameters** - Full validation with JSON Schema compatible definitions
+- **Async throughout** - All tools are async/await compatible
+- **Memory integration** - Introspection tools access episodic/semantic memory
+
+---
+
 ## [0.12.0] - 2026-02-02
 
 ### Added

--- a/docs/plans/ai-first-implementation-plan.md
+++ b/docs/plans/ai-first-implementation-plan.md
@@ -68,8 +68,8 @@ MarketPattern    # Identified patterns with statistics
 
 ---
 
-## Phase 3: Agent Tools
-**Duration**: 2-3 weeks | **Dependency**: Phase 2 complete
+## Phase 3: Agent Tools ✅ COMPLETE
+**Duration**: 2-3 weeks | **Dependency**: Phase 2 complete | **Version**: v0.13.0
 
 ### New Module: `keryxflow/agent/`
 | File | Purpose |
@@ -89,10 +89,10 @@ MarketPattern    # Identified patterns with statistics
 | Execution | place_order, close_position, set_stop_loss | **YES** |
 
 ### Success Criteria
-- [ ] 15+ tools implemented and tested
-- [ ] Execution tools pass through GuardrailEnforcer
-- [ ] Format compatible with Anthropic Tool Use API
-- [ ] Robust error handling
+- [x] 15+ tools implemented and tested (20 tools total)
+- [x] Execution tools pass through GuardrailEnforcer
+- [x] Format compatible with Anthropic Tool Use API
+- [x] Robust error handling
 
 ---
 

--- a/keryxflow/agent/__init__.py
+++ b/keryxflow/agent/__init__.py
@@ -1,0 +1,40 @@
+"""Agent module for AI-first trading.
+
+This module provides tools and infrastructure for the cognitive trading agent
+to perceive market conditions, analyze data, and execute trades safely.
+
+Tool Categories:
+- PERCEPTION: Read-only market data (get_price, get_ohlcv, etc.)
+- ANALYSIS: Computation tools (calculate_indicators, position_size, etc.)
+- INTROSPECTION: Memory access (get_trading_rules, recall_similar_trades)
+- EXECUTION: Order execution - GUARDED (place_order, close_position, etc.)
+"""
+
+from keryxflow.agent.executor import ToolExecutor, get_tool_executor
+from keryxflow.agent.tools import (
+    BaseTool,
+    ToolCategory,
+    ToolParameter,
+    ToolResult,
+    TradingToolkit,
+    create_tool,
+    get_trading_toolkit,
+    register_all_tools,
+)
+
+__all__ = [
+    # Base classes
+    "BaseTool",
+    "ToolCategory",
+    "ToolParameter",
+    "ToolResult",
+    # Toolkit
+    "TradingToolkit",
+    "get_trading_toolkit",
+    "register_all_tools",
+    # Executor
+    "ToolExecutor",
+    "get_tool_executor",
+    # Decorator
+    "create_tool",
+]

--- a/keryxflow/agent/analysis_tools.py
+++ b/keryxflow/agent/analysis_tools.py
@@ -1,0 +1,808 @@
+"""Analysis tools for technical analysis and calculations.
+
+These tools perform computations and analysis but do not modify state.
+They do not require guardrail validation.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pandas as pd
+
+from keryxflow.agent.tools import (
+    BaseTool,
+    ToolCategory,
+    ToolParameter,
+    ToolResult,
+    TradingToolkit,
+)
+from keryxflow.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class CalculateIndicatorsTool(BaseTool):
+    """Calculate technical indicators for a trading pair."""
+
+    @property
+    def name(self) -> str:
+        return "calculate_indicators"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Calculate technical indicators (RSI, MACD, Bollinger Bands, etc.) "
+            "for a trading pair. Returns analysis with trend direction and strength."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.ANALYSIS
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol (e.g., 'BTC/USDT')",
+                required=True,
+            ),
+            ToolParameter(
+                name="timeframe",
+                type="string",
+                description="Candlestick timeframe for analysis",
+                required=False,
+                default="1h",
+                enum=["1m", "5m", "15m", "30m", "1h", "4h", "1d"],
+            ),
+            ToolParameter(
+                name="limit",
+                type="integer",
+                description="Number of candles to analyze (min 50 for reliable indicators)",
+                required=False,
+                default=100,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs["symbol"]
+        timeframe = kwargs.get("timeframe", "1h")
+        limit = max(kwargs.get("limit", 100), 50)  # Minimum 50 for indicators
+
+        try:
+            # Fetch OHLCV data
+            from keryxflow.exchange.client import get_exchange_client
+
+            client = get_exchange_client()
+            ohlcv = await client.fetch_ohlcv(symbol, timeframe, limit=limit)
+
+            if len(ohlcv) < 30:
+                return ToolResult(
+                    success=False,
+                    error=f"Insufficient data for analysis. Got {len(ohlcv)} candles, need at least 30.",
+                )
+
+            # Convert to DataFrame
+            df = pd.DataFrame(
+                ohlcv,
+                columns=["timestamp", "open", "high", "low", "close", "volume"],
+            )
+            df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms", utc=True)
+
+            # Run technical analysis
+            from keryxflow.oracle.technical import get_technical_analyzer
+
+            analyzer = get_technical_analyzer()
+            analysis = analyzer.analyze(df, symbol)
+
+            # Format indicator results
+            indicators_data = {}
+            for name, indicator in analysis.indicators.items():
+                indicators_data[name] = {
+                    "value": indicator.value,
+                    "signal": indicator.signal.value,
+                    "strength": indicator.strength.value,
+                    "simple_explanation": indicator.simple_explanation,
+                    "technical_explanation": indicator.technical_explanation,
+                }
+
+            return ToolResult(
+                success=True,
+                data={
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "overall_trend": analysis.overall_trend.value,
+                    "overall_strength": analysis.overall_strength.value,
+                    "confidence": analysis.confidence,
+                    "simple_summary": analysis.simple_summary,
+                    "technical_summary": analysis.technical_summary,
+                    "indicators": indicators_data,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("calculate_indicators_failed", symbol=symbol, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to calculate indicators for {symbol}: {str(e)}",
+            )
+
+
+class CalculatePositionSizeTool(BaseTool):
+    """Calculate optimal position size based on risk parameters."""
+
+    @property
+    def name(self) -> str:
+        return "calculate_position_size"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Calculate the optimal position size based on account balance, "
+            "entry price, stop loss, and risk percentage per trade. "
+            "Uses proper risk management to limit losses."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.ANALYSIS
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="balance",
+                type="number",
+                description="Account balance in quote currency (e.g., USDT)",
+                required=True,
+            ),
+            ToolParameter(
+                name="entry_price",
+                type="number",
+                description="Planned entry price",
+                required=True,
+            ),
+            ToolParameter(
+                name="stop_loss",
+                type="number",
+                description="Stop loss price",
+                required=True,
+            ),
+            ToolParameter(
+                name="risk_pct",
+                type="number",
+                description="Risk percentage per trade (e.g., 0.01 for 1%)",
+                required=False,
+                default=0.01,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        balance = kwargs["balance"]
+        entry_price = kwargs["entry_price"]
+        stop_loss = kwargs["stop_loss"]
+        risk_pct = kwargs.get("risk_pct", 0.01)
+
+        try:
+            from keryxflow.aegis.quant import get_quant_engine
+
+            quant = get_quant_engine()
+
+            result = quant.position_size(
+                balance=balance,
+                entry_price=entry_price,
+                stop_loss=stop_loss,
+                risk_per_trade=risk_pct,
+            )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "quantity": result.quantity,
+                    "position_value": result.position_value,
+                    "risk_amount": result.risk_amount,
+                    "risk_percentage": result.risk_percentage,
+                    "stop_distance": result.stop_distance,
+                    "simple_explanation": result.simple_explanation,
+                    "technical_details": result.technical_details,
+                },
+            )
+
+        except ValueError as e:
+            return ToolResult(
+                success=False,
+                error=str(e),
+            )
+        except Exception as e:
+            logger.error("calculate_position_size_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to calculate position size: {str(e)}",
+            )
+
+
+class CalculateRiskRewardTool(BaseTool):
+    """Calculate risk/reward ratio for a trade."""
+
+    @property
+    def name(self) -> str:
+        return "calculate_risk_reward"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Calculate the risk/reward ratio for a planned trade. "
+            "Returns potential profit, potential loss, and the R:R ratio. "
+            "A ratio >= 2.0 is generally considered favorable."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.ANALYSIS
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="entry_price",
+                type="number",
+                description="Entry price for the trade",
+                required=True,
+            ),
+            ToolParameter(
+                name="stop_loss",
+                type="number",
+                description="Stop loss price",
+                required=True,
+            ),
+            ToolParameter(
+                name="take_profit",
+                type="number",
+                description="Take profit target price",
+                required=True,
+            ),
+            ToolParameter(
+                name="quantity",
+                type="number",
+                description="Position quantity (for calculating dollar amounts)",
+                required=False,
+                default=1.0,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        entry_price = kwargs["entry_price"]
+        stop_loss = kwargs["stop_loss"]
+        take_profit = kwargs["take_profit"]
+        quantity = kwargs.get("quantity", 1.0)
+
+        try:
+            from keryxflow.aegis.quant import get_quant_engine
+
+            quant = get_quant_engine()
+
+            result = quant.risk_reward_ratio(
+                entry_price=entry_price,
+                stop_loss=stop_loss,
+                take_profit=take_profit,
+                quantity=quantity,
+            )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "ratio": result.ratio,
+                    "potential_profit": result.potential_profit,
+                    "potential_loss": result.potential_loss,
+                    "breakeven_winrate": result.breakeven_winrate,
+                    "is_favorable": result.is_favorable,
+                    "simple_explanation": result.simple_explanation,
+                },
+            )
+
+        except ValueError as e:
+            return ToolResult(
+                success=False,
+                error=str(e),
+            )
+        except Exception as e:
+            logger.error("calculate_risk_reward_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to calculate risk/reward: {str(e)}",
+            )
+
+
+class GetTradingRulesTool(BaseTool):
+    """Get active trading rules from semantic memory."""
+
+    @property
+    def name(self) -> str:
+        return "get_trading_rules"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get active trading rules from memory. Rules can be learned from "
+            "past trades, defined by users, or discovered through backtesting. "
+            "Use these rules to inform trading decisions."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.INTROSPECTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Filter rules by symbol (optional)",
+                required=False,
+            ),
+            ToolParameter(
+                name="context",
+                type="object",
+                description="Market context to match rules against (optional)",
+                required=False,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs.get("symbol")
+        context = kwargs.get("context", {})
+
+        try:
+            from keryxflow.memory.semantic import get_semantic_memory
+
+            semantic = get_semantic_memory()
+
+            if context:
+                rules = await semantic.get_matching_rules(
+                    symbol=symbol,
+                    context=context,
+                )
+            else:
+                rules = await semantic.get_active_rules(symbol=symbol)
+
+            rules_data = []
+            for rule in rules:
+                rules_data.append(
+                    {
+                        "id": rule.id,
+                        "name": rule.name,
+                        "description": rule.description,
+                        "condition": rule.condition,
+                        "action": rule.action,
+                        "source": rule.source.value,
+                        "confidence": rule.confidence,
+                        "win_rate": rule.win_rate,
+                        "total_applications": rule.total_applications,
+                        "successful_applications": rule.successful_applications,
+                    }
+                )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "rules": rules_data,
+                    "count": len(rules_data),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("get_trading_rules_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to get trading rules: {str(e)}",
+            )
+
+
+class RecallSimilarTradesTool(BaseTool):
+    """Recall similar trades from episodic memory."""
+
+    @property
+    def name(self) -> str:
+        return "recall_similar_trades"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Recall similar past trades from memory based on current market context. "
+            "Returns trades with similar technical conditions and their outcomes. "
+            "Use this to learn from past experiences."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.INTROSPECTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol",
+                required=True,
+            ),
+            ToolParameter(
+                name="rsi",
+                type="number",
+                description="Current RSI value (optional but improves matching)",
+                required=False,
+            ),
+            ToolParameter(
+                name="trend",
+                type="string",
+                description="Current trend direction",
+                required=False,
+                enum=["bullish", "bearish", "neutral"],
+            ),
+            ToolParameter(
+                name="macd_signal",
+                type="string",
+                description="Current MACD signal",
+                required=False,
+                enum=["bullish", "bearish", "neutral"],
+            ),
+            ToolParameter(
+                name="limit",
+                type="integer",
+                description="Maximum number of similar trades to return",
+                required=False,
+                default=5,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs["symbol"]
+        rsi = kwargs.get("rsi")
+        trend = kwargs.get("trend")
+        macd_signal = kwargs.get("macd_signal")
+        limit = kwargs.get("limit", 5)
+
+        try:
+            from keryxflow.memory.episodic import get_episodic_memory
+
+            episodic = get_episodic_memory()
+
+            # Build technical_indicators dict for matching
+            technical_indicators = {}
+            if rsi is not None:
+                technical_indicators["rsi"] = rsi
+            if trend:
+                technical_indicators["trend"] = trend
+            if macd_signal:
+                technical_indicators["macd_signal"] = macd_signal
+
+            # Call recall_similar with correct parameters
+            matches = await episodic.recall_similar(
+                symbol=symbol,
+                technical_indicators=technical_indicators if technical_indicators else None,
+                limit=limit,
+            )
+
+            episodes_data = []
+            for match in matches:
+                episode = match.episode
+                episodes_data.append(
+                    {
+                        "id": episode.id,
+                        "trade_id": episode.trade_id,
+                        "symbol": episode.symbol,
+                        "side": episode.side,
+                        "entry_price": episode.entry_price,
+                        "exit_price": episode.exit_price,
+                        "pnl": episode.pnl,
+                        "pnl_percentage": episode.pnl_percentage,
+                        "outcome": episode.outcome.value if episode.outcome else None,
+                        "entry_reasoning": episode.entry_reasoning,
+                        "lessons_learned": episode.lessons_learned,
+                        "similarity_score": match.similarity_score,
+                        "entry_timestamp": episode.entry_timestamp.isoformat()
+                        if episode.entry_timestamp
+                        else None,
+                    }
+                )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "similar_trades": episodes_data,
+                    "count": len(episodes_data),
+                    "context_used": technical_indicators,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("recall_similar_trades_failed", symbol=symbol, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to recall similar trades: {str(e)}",
+            )
+
+
+class GetMarketPatternsTool(BaseTool):
+    """Get identified market patterns from semantic memory."""
+
+    @property
+    def name(self) -> str:
+        return "get_market_patterns"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get identified market patterns from memory that match the current "
+            "technical context. Patterns include technical patterns, price action "
+            "patterns, and time-based patterns that have been observed and validated."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.INTROSPECTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="rsi",
+                type="number",
+                description="Current RSI value (helps find matching patterns)",
+                required=False,
+            ),
+            ToolParameter(
+                name="trend",
+                type="string",
+                description="Current trend direction",
+                required=False,
+                enum=["bullish", "bearish", "neutral"],
+            ),
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Filter patterns by symbol (optional)",
+                required=False,
+            ),
+            ToolParameter(
+                name="timeframe",
+                type="string",
+                description="Filter patterns by timeframe (optional)",
+                required=False,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        rsi = kwargs.get("rsi")
+        trend = kwargs.get("trend")
+        symbol = kwargs.get("symbol")
+        timeframe = kwargs.get("timeframe")
+
+        try:
+            from keryxflow.memory.semantic import get_semantic_memory
+
+            semantic = get_semantic_memory()
+
+            # Build technical context for matching
+            technical_context = {}
+            if rsi is not None:
+                technical_context["rsi"] = rsi
+            if trend:
+                technical_context["trend"] = trend
+
+            # If no context provided, use empty dict (will return all valid patterns)
+            matches = await semantic.find_matching_patterns(
+                technical_context=technical_context,
+                symbol=symbol,
+                timeframe=timeframe,
+            )
+
+            patterns_data = []
+            for match in matches:
+                pattern = match.pattern
+                patterns_data.append(
+                    {
+                        "id": pattern.id,
+                        "name": pattern.name,
+                        "description": pattern.description,
+                        "pattern_type": pattern.pattern_type.value,
+                        "symbol": pattern.symbol,
+                        "timeframe": pattern.timeframe,
+                        "conditions": pattern.conditions,
+                        "expected_outcome": pattern.expected_outcome,
+                        "confidence": pattern.confidence,
+                        "occurrences": pattern.occurrences,
+                        "success_rate": pattern.success_rate,
+                        "match_score": match.match_score,
+                    }
+                )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "patterns": patterns_data,
+                    "count": len(patterns_data),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("get_market_patterns_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to get market patterns: {str(e)}",
+            )
+
+
+class CalculateStopLossTool(BaseTool):
+    """Calculate stop loss price based on ATR or fixed percentage."""
+
+    @property
+    def name(self) -> str:
+        return "calculate_stop_loss"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Calculate an appropriate stop loss price based on market volatility (ATR) "
+            "or a fixed percentage from entry. ATR-based stops adapt to current volatility."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.ANALYSIS
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="entry_price",
+                type="number",
+                description="Entry price for the trade",
+                required=True,
+            ),
+            ToolParameter(
+                name="side",
+                type="string",
+                description="Trade side",
+                required=True,
+                enum=["buy", "sell"],
+            ),
+            ToolParameter(
+                name="method",
+                type="string",
+                description="Stop loss calculation method",
+                required=False,
+                default="fixed",
+                enum=["fixed", "atr"],
+            ),
+            ToolParameter(
+                name="percentage",
+                type="number",
+                description="Fixed percentage for stop (e.g., 0.02 for 2%)",
+                required=False,
+                default=0.02,
+            ),
+            ToolParameter(
+                name="atr_multiplier",
+                type="number",
+                description="ATR multiplier for volatility-based stop",
+                required=False,
+                default=2.0,
+            ),
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Symbol for ATR calculation (required if method is 'atr')",
+                required=False,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        entry_price = kwargs["entry_price"]
+        side = kwargs["side"]
+        method = kwargs.get("method", "fixed")
+        percentage = kwargs.get("percentage", 0.02)
+        atr_multiplier = kwargs.get("atr_multiplier", 2.0)
+        symbol = kwargs.get("symbol")
+
+        try:
+            from keryxflow.aegis.quant import get_quant_engine
+
+            quant = get_quant_engine()
+
+            if method == "fixed":
+                stop_price = quant.fixed_percentage_stop(
+                    entry_price=entry_price,
+                    side=side,
+                    percentage=percentage,
+                )
+                method_used = f"Fixed {percentage*100:.1f}%"
+
+            elif method == "atr":
+                if not symbol:
+                    return ToolResult(
+                        success=False,
+                        error="Symbol is required for ATR-based stop loss",
+                    )
+
+                # Fetch recent price data for ATR calculation
+                from keryxflow.exchange.client import get_exchange_client
+
+                client = get_exchange_client()
+                ohlcv = await client.fetch_ohlcv(symbol, "1h", limit=20)
+
+                if len(ohlcv) < 15:
+                    return ToolResult(
+                        success=False,
+                        error="Insufficient data for ATR calculation",
+                    )
+
+                highs = [c[2] for c in ohlcv]
+                lows = [c[3] for c in ohlcv]
+                closes = [c[4] for c in ohlcv]
+
+                stop_price = quant.atr_stop_loss(
+                    prices_high=highs,
+                    prices_low=lows,
+                    prices_close=closes,
+                    entry_price=entry_price,
+                    side=side,
+                    multiplier=atr_multiplier,
+                )
+                method_used = f"ATR x{atr_multiplier}"
+
+            else:
+                return ToolResult(
+                    success=False,
+                    error=f"Unknown method: {method}",
+                )
+
+            distance = abs(entry_price - stop_price)
+            distance_pct = distance / entry_price
+
+            return ToolResult(
+                success=True,
+                data={
+                    "stop_loss": stop_price,
+                    "entry_price": entry_price,
+                    "distance": distance,
+                    "distance_pct": distance_pct * 100,
+                    "method": method_used,
+                    "side": side,
+                },
+            )
+
+        except Exception as e:
+            logger.error("calculate_stop_loss_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to calculate stop loss: {str(e)}",
+            )
+
+
+def register_analysis_tools(toolkit: TradingToolkit) -> None:
+    """Register all analysis tools with the toolkit.
+
+    Args:
+        toolkit: The toolkit to register tools with
+    """
+    tools = [
+        CalculateIndicatorsTool(),
+        CalculatePositionSizeTool(),
+        CalculateRiskRewardTool(),
+        GetTradingRulesTool(),
+        RecallSimilarTradesTool(),
+        GetMarketPatternsTool(),
+        CalculateStopLossTool(),
+    ]
+
+    for tool in tools:
+        toolkit.register(tool)
+
+    logger.info("analysis_tools_registered", count=len(tools))

--- a/keryxflow/agent/execution_tools.py
+++ b/keryxflow/agent/execution_tools.py
@@ -1,0 +1,826 @@
+"""Execution tools for order management.
+
+THESE TOOLS ARE GUARDED and require validation through GuardrailEnforcer
+before execution. They modify portfolio state and place real/paper orders.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from keryxflow.agent.tools import (
+    BaseTool,
+    ToolCategory,
+    ToolParameter,
+    ToolResult,
+    TradingToolkit,
+)
+from keryxflow.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class PlaceOrderTool(BaseTool):
+    """Place a market or limit order.
+
+    This tool is GUARDED and will validate against guardrails before execution.
+    """
+
+    @property
+    def name(self) -> str:
+        return "place_order"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Place a buy or sell order for a trading pair. "
+            "Orders are validated against risk guardrails before execution. "
+            "For safety, always use a stop loss."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.EXECUTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol (e.g., 'BTC/USDT')",
+                required=True,
+            ),
+            ToolParameter(
+                name="side",
+                type="string",
+                description="Order side",
+                required=True,
+                enum=["buy", "sell"],
+            ),
+            ToolParameter(
+                name="quantity",
+                type="number",
+                description="Quantity to buy/sell in base currency",
+                required=True,
+            ),
+            ToolParameter(
+                name="order_type",
+                type="string",
+                description="Order type",
+                required=False,
+                default="market",
+                enum=["market", "limit"],
+            ),
+            ToolParameter(
+                name="price",
+                type="number",
+                description="Limit price (required for limit orders)",
+                required=False,
+            ),
+            ToolParameter(
+                name="stop_loss",
+                type="number",
+                description="Stop loss price (strongly recommended)",
+                required=False,
+            ),
+            ToolParameter(
+                name="take_profit",
+                type="number",
+                description="Take profit price (optional)",
+                required=False,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs["symbol"]
+        side = kwargs["side"]
+        quantity = kwargs["quantity"]
+        order_type = kwargs.get("order_type", "market")
+        price = kwargs.get("price")
+        stop_loss = kwargs.get("stop_loss")
+        take_profit = kwargs.get("take_profit")
+
+        # Validate limit order has price
+        if order_type == "limit" and price is None:
+            return ToolResult(
+                success=False,
+                error="Limit orders require a price parameter",
+            )
+
+        try:
+            # Get current price if not provided
+            if price is None:
+                from keryxflow.exchange.orders import get_order_manager
+
+                order_manager = get_order_manager()
+                await order_manager.initialize()
+
+                # Get current price from paper engine or fetch it
+                if order_manager.is_paper_mode:
+                    from keryxflow.exchange.paper import get_paper_engine
+
+                    engine = get_paper_engine()
+                    price = engine.get_price(symbol)
+
+                if price is None:
+                    from keryxflow.exchange.client import get_exchange_client
+
+                    client = get_exchange_client()
+                    ticker = await client.fetch_ticker(symbol)
+                    price = ticker.get("last", ticker.get("close"))
+
+            if price is None:
+                return ToolResult(
+                    success=False,
+                    error=f"Could not determine current price for {symbol}",
+                )
+
+            # Validate against guardrails
+            from keryxflow.aegis.guardrails import get_guardrail_enforcer
+            from keryxflow.aegis.risk import get_risk_manager
+
+            risk_manager = get_risk_manager()
+            enforcer = get_guardrail_enforcer()
+
+            guardrail_result = enforcer.validate_order(
+                symbol=symbol,
+                side=side,
+                quantity=quantity,
+                entry_price=price,
+                stop_loss=stop_loss,
+                portfolio=risk_manager.portfolio_state,
+            )
+
+            if not guardrail_result.allowed:
+                logger.warning(
+                    "order_blocked_by_guardrails",
+                    symbol=symbol,
+                    side=side,
+                    quantity=quantity,
+                    violation=guardrail_result.violation.value
+                    if guardrail_result.violation
+                    else None,
+                    message=guardrail_result.message,
+                )
+                return ToolResult(
+                    success=False,
+                    error=f"Order blocked by guardrails: {guardrail_result.message}",
+                    metadata={
+                        "violation": guardrail_result.violation.value
+                        if guardrail_result.violation
+                        else None,
+                        "details": guardrail_result.details,
+                    },
+                )
+
+            # Validate against risk manager
+            from keryxflow.aegis.risk import OrderRequest
+
+            order_request = OrderRequest(
+                symbol=symbol,
+                side=side,
+                quantity=quantity,
+                entry_price=price,
+                stop_loss=stop_loss,
+                take_profit=take_profit,
+            )
+
+            approval = risk_manager.approve_order(order_request)
+
+            if not approval.approved:
+                logger.warning(
+                    "order_rejected_by_risk",
+                    symbol=symbol,
+                    side=side,
+                    quantity=quantity,
+                    reason=approval.reason.value if approval.reason else None,
+                )
+                return ToolResult(
+                    success=False,
+                    error=f"Order rejected by risk manager: {approval.simple_message}",
+                    metadata={
+                        "reason": approval.reason.value if approval.reason else None,
+                        "suggested_quantity": approval.suggested_quantity,
+                        "suggested_stop_loss": approval.suggested_stop_loss,
+                    },
+                )
+
+            # Execute the order
+            from keryxflow.exchange.orders import get_order_manager
+
+            order_manager = get_order_manager()
+            await order_manager.initialize()
+
+            if order_type == "market":
+                order = await order_manager.place_market_order(
+                    symbol=symbol,
+                    side=side,
+                    amount=quantity,
+                )
+            else:
+                order = await order_manager.place_limit_order(
+                    symbol=symbol,
+                    side=side,
+                    amount=quantity,
+                    price=price,
+                )
+
+            # If market order filled, open position with stop/take profit
+            if order.status.value == "filled" and order_manager.is_paper_mode:
+                from keryxflow.exchange.paper import get_paper_engine
+
+                engine = get_paper_engine()
+                await engine.open_position(
+                    symbol=symbol,
+                    side=side,
+                    amount=quantity,
+                    entry_price=order.average_price or price,
+                    stop_loss=stop_loss,
+                    take_profit=take_profit,
+                )
+
+                # Update portfolio state
+                risk_manager.add_position_to_portfolio(
+                    symbol=symbol,
+                    side=side,
+                    quantity=quantity,
+                    entry_price=order.average_price or price,
+                    stop_loss=stop_loss,
+                    take_profit=take_profit,
+                )
+
+            logger.info(
+                "order_placed",
+                order_id=order.id,
+                symbol=symbol,
+                side=side,
+                quantity=quantity,
+                price=order.average_price or price,
+                status=order.status.value,
+            )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "order_id": order.id,
+                    "symbol": symbol,
+                    "side": side,
+                    "type": order_type,
+                    "quantity": quantity,
+                    "price": order.average_price or price,
+                    "status": order.status.value,
+                    "filled": order.filled,
+                    "stop_loss": stop_loss,
+                    "take_profit": take_profit,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("place_order_failed", symbol=symbol, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to place order: {str(e)}",
+            )
+
+
+class ClosePositionTool(BaseTool):
+    """Close an open position.
+
+    This tool is GUARDED.
+    """
+
+    @property
+    def name(self) -> str:
+        return "close_position"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Close an open trading position. "
+            "This will sell all holdings for the specified symbol "
+            "at the current market price."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.EXECUTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol to close position for",
+                required=True,
+            ),
+            ToolParameter(
+                name="reason",
+                type="string",
+                description="Reason for closing the position (for logging)",
+                required=False,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs["symbol"]
+        reason = kwargs.get("reason", "Manual close via agent")
+
+        try:
+            from keryxflow.exchange.paper import get_paper_engine
+
+            engine = get_paper_engine()
+            await engine.initialize()
+
+            # Check if position exists
+            position = await engine.get_position(symbol)
+            if position is None:
+                return ToolResult(
+                    success=False,
+                    error=f"No open position for {symbol}",
+                )
+
+            # Get current price
+            current_price = engine.get_price(symbol) or position.current_price
+
+            # Close the position
+            result = await engine.close_position(symbol, current_price)
+
+            if result is None:
+                return ToolResult(
+                    success=False,
+                    error=f"Failed to close position for {symbol}",
+                )
+
+            # Update portfolio state
+            from keryxflow.aegis.risk import get_risk_manager
+
+            risk_manager = get_risk_manager()
+            risk_manager.close_position_in_portfolio(symbol, current_price)
+
+            logger.info(
+                "position_closed",
+                symbol=symbol,
+                exit_price=current_price,
+                pnl=result.get("pnl"),
+                reason=reason,
+            )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "symbol": symbol,
+                    "exit_price": current_price,
+                    "quantity": result.get("quantity"),
+                    "pnl": result.get("pnl"),
+                    "pnl_percentage": result.get("pnl_percentage"),
+                    "reason": reason,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("close_position_failed", symbol=symbol, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to close position: {str(e)}",
+            )
+
+
+class SetStopLossTool(BaseTool):
+    """Update stop loss for an open position.
+
+    This tool is GUARDED.
+    """
+
+    @property
+    def name(self) -> str:
+        return "set_stop_loss"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Update the stop loss price for an open position. "
+            "Stop loss orders automatically close the position if price falls below (for longs) "
+            "or rises above (for shorts) the specified level."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.EXECUTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol",
+                required=True,
+            ),
+            ToolParameter(
+                name="stop_loss",
+                type="number",
+                description="New stop loss price",
+                required=True,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs["symbol"]
+        stop_loss = kwargs["stop_loss"]
+
+        try:
+            from keryxflow.exchange.paper import get_paper_engine
+
+            engine = get_paper_engine()
+            await engine.initialize()
+
+            # Check if position exists
+            position = await engine.get_position(symbol)
+            if position is None:
+                return ToolResult(
+                    success=False,
+                    error=f"No open position for {symbol}",
+                )
+
+            # Validate stop loss direction
+            if position.side.value == "buy":
+                # Long position - stop must be below entry
+                if stop_loss >= position.entry_price:
+                    return ToolResult(
+                        success=False,
+                        error=f"Stop loss ({stop_loss}) must be below entry price ({position.entry_price}) for long positions",
+                    )
+            else:
+                # Short position - stop must be above entry
+                if stop_loss <= position.entry_price:
+                    return ToolResult(
+                        success=False,
+                        error=f"Stop loss ({stop_loss}) must be above entry price ({position.entry_price}) for short positions",
+                    )
+
+            # Update the position stop loss in database
+            from keryxflow.core.database import get_session_factory
+            from keryxflow.core.models import Position as PositionModel
+
+            async_session = get_session_factory()
+            async with async_session() as session:
+                from sqlmodel import select
+
+                result = await session.execute(
+                    select(PositionModel).where(PositionModel.symbol == symbol)
+                )
+                db_position = result.scalar_one_or_none()
+
+                if db_position:
+                    old_stop = db_position.stop_loss
+                    db_position.stop_loss = stop_loss
+                    await session.commit()
+
+            logger.info(
+                "stop_loss_updated",
+                symbol=symbol,
+                old_stop=old_stop,
+                new_stop=stop_loss,
+            )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "symbol": symbol,
+                    "old_stop_loss": old_stop,
+                    "new_stop_loss": stop_loss,
+                    "entry_price": position.entry_price,
+                    "current_price": position.current_price,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("set_stop_loss_failed", symbol=symbol, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to set stop loss: {str(e)}",
+            )
+
+
+class SetTakeProfitTool(BaseTool):
+    """Update take profit for an open position.
+
+    This tool is GUARDED.
+    """
+
+    @property
+    def name(self) -> str:
+        return "set_take_profit"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Update the take profit price for an open position. "
+            "Take profit orders automatically close the position when price reaches "
+            "the target level to lock in profits."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.EXECUTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol",
+                required=True,
+            ),
+            ToolParameter(
+                name="take_profit",
+                type="number",
+                description="New take profit price",
+                required=True,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs["symbol"]
+        take_profit = kwargs["take_profit"]
+
+        try:
+            from keryxflow.exchange.paper import get_paper_engine
+
+            engine = get_paper_engine()
+            await engine.initialize()
+
+            # Check if position exists
+            position = await engine.get_position(symbol)
+            if position is None:
+                return ToolResult(
+                    success=False,
+                    error=f"No open position for {symbol}",
+                )
+
+            # Validate take profit direction
+            if position.side.value == "buy":
+                # Long position - TP must be above entry
+                if take_profit <= position.entry_price:
+                    return ToolResult(
+                        success=False,
+                        error=f"Take profit ({take_profit}) must be above entry price ({position.entry_price}) for long positions",
+                    )
+            else:
+                # Short position - TP must be below entry
+                if take_profit >= position.entry_price:
+                    return ToolResult(
+                        success=False,
+                        error=f"Take profit ({take_profit}) must be below entry price ({position.entry_price}) for short positions",
+                    )
+
+            # Update the position take profit in database
+            from keryxflow.core.database import get_session_factory
+            from keryxflow.core.models import Position as PositionModel
+
+            async_session = get_session_factory()
+            async with async_session() as session:
+                from sqlmodel import select
+
+                result = await session.execute(
+                    select(PositionModel).where(PositionModel.symbol == symbol)
+                )
+                db_position = result.scalar_one_or_none()
+
+                if db_position:
+                    old_tp = db_position.take_profit
+                    db_position.take_profit = take_profit
+                    await session.commit()
+
+            logger.info(
+                "take_profit_updated",
+                symbol=symbol,
+                old_tp=old_tp,
+                new_tp=take_profit,
+            )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "symbol": symbol,
+                    "old_take_profit": old_tp,
+                    "new_take_profit": take_profit,
+                    "entry_price": position.entry_price,
+                    "current_price": position.current_price,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("set_take_profit_failed", symbol=symbol, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to set take profit: {str(e)}",
+            )
+
+
+class CancelOrderTool(BaseTool):
+    """Cancel a pending order.
+
+    This tool is GUARDED.
+    """
+
+    @property
+    def name(self) -> str:
+        return "cancel_order"
+
+    @property
+    def description(self) -> str:
+        return "Cancel a pending (unfilled) order by its order ID."
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.EXECUTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="order_id",
+                type="string",
+                description="ID of the order to cancel",
+                required=True,
+            ),
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol (required for exchange API)",
+                required=True,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        order_id = kwargs["order_id"]
+        symbol = kwargs["symbol"]
+
+        try:
+            from keryxflow.exchange.orders import get_order_manager
+
+            order_manager = get_order_manager()
+            await order_manager.initialize()
+
+            success = await order_manager.cancel_order(order_id, symbol)
+
+            if success:
+                logger.info("order_cancelled", order_id=order_id, symbol=symbol)
+                return ToolResult(
+                    success=True,
+                    data={
+                        "order_id": order_id,
+                        "symbol": symbol,
+                        "cancelled": True,
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    },
+                )
+            else:
+                return ToolResult(
+                    success=False,
+                    error=f"Could not cancel order {order_id}. It may already be filled or not exist.",
+                )
+
+        except Exception as e:
+            logger.error("cancel_order_failed", order_id=order_id, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to cancel order: {str(e)}",
+            )
+
+
+class CloseAllPositionsTool(BaseTool):
+    """Close all open positions (panic mode).
+
+    This tool is GUARDED.
+    """
+
+    @property
+    def name(self) -> str:
+        return "close_all_positions"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Emergency action to close ALL open positions immediately. "
+            "Use this in panic situations or when circuit breaker triggers. "
+            "This is an irreversible action."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.EXECUTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="reason",
+                type="string",
+                description="Reason for closing all positions",
+                required=True,
+            ),
+            ToolParameter(
+                name="confirm",
+                type="boolean",
+                description="Confirmation flag - must be true to execute",
+                required=True,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        reason = kwargs["reason"]
+        confirm = kwargs["confirm"]
+
+        if not confirm:
+            return ToolResult(
+                success=False,
+                error="Action not confirmed. Set confirm=true to close all positions.",
+            )
+
+        try:
+            from keryxflow.exchange.paper import get_paper_engine
+
+            engine = get_paper_engine()
+            await engine.initialize()
+
+            # Get all positions before closing
+            positions = await engine.get_positions()
+            if not positions:
+                return ToolResult(
+                    success=True,
+                    data={
+                        "message": "No open positions to close",
+                        "closed_count": 0,
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    },
+                )
+
+            # Close all positions
+            results = await engine.close_all_positions()
+
+            total_pnl = 0
+            closed_data = []
+            for result in results:
+                pnl = result.get("pnl", 0)
+                total_pnl += pnl
+                closed_data.append(
+                    {
+                        "symbol": result.get("symbol"),
+                        "exit_price": result.get("price"),
+                        "pnl": pnl,
+                    }
+                )
+
+            logger.warning(
+                "all_positions_closed",
+                reason=reason,
+                closed_count=len(results),
+                total_pnl=total_pnl,
+            )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "reason": reason,
+                    "closed_count": len(results),
+                    "total_pnl": total_pnl,
+                    "positions_closed": closed_data,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("close_all_positions_failed", reason=reason, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to close all positions: {str(e)}",
+            )
+
+
+def register_execution_tools(toolkit: TradingToolkit) -> None:
+    """Register all execution tools with the toolkit.
+
+    Args:
+        toolkit: The toolkit to register tools with
+    """
+    tools = [
+        PlaceOrderTool(),
+        ClosePositionTool(),
+        SetStopLossTool(),
+        SetTakeProfitTool(),
+        CancelOrderTool(),
+        CloseAllPositionsTool(),
+    ]
+
+    for tool in tools:
+        toolkit.register(tool)
+
+    logger.info("execution_tools_registered", count=len(tools))

--- a/keryxflow/agent/executor.py
+++ b/keryxflow/agent/executor.py
@@ -1,0 +1,463 @@
+"""Safe tool executor with guardrail integration.
+
+The ToolExecutor provides a safe wrapper around tool execution that:
+- Validates guarded tools against guardrails before execution
+- Logs all tool executions for auditing
+- Publishes events for tool execution lifecycle
+- Handles errors gracefully
+- Enforces rate limits
+"""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from keryxflow.agent.tools import (
+    BaseTool,
+    ToolCategory,
+    ToolResult,
+    TradingToolkit,
+    get_trading_toolkit,
+)
+from keryxflow.core.events import Event, EventType, get_event_bus
+from keryxflow.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ExecutionRecord:
+    """Record of a tool execution."""
+
+    tool_name: str
+    category: ToolCategory
+    parameters: dict[str, Any]
+    result: ToolResult
+    started_at: datetime
+    completed_at: datetime
+    duration_ms: float
+    was_guarded: bool
+    guardrail_passed: bool | None = None
+
+
+@dataclass
+class ExecutorStats:
+    """Statistics for tool executor."""
+
+    total_executions: int = 0
+    successful_executions: int = 0
+    failed_executions: int = 0
+    blocked_by_guardrails: int = 0
+    executions_by_category: dict[str, int] = field(default_factory=dict)
+    last_execution_time: datetime | None = None
+
+
+class ToolExecutor:
+    """Safe executor for agent tools with guardrail integration.
+
+    The executor wraps tool execution to ensure:
+    1. Guarded tools (execution) are validated before running
+    2. All executions are logged and can be audited
+    3. Events are published for tool lifecycle
+    4. Errors are handled gracefully
+    5. Rate limits are enforced
+
+    Example:
+        executor = ToolExecutor()
+
+        # Execute a tool
+        result = await executor.execute("get_current_price", symbol="BTC/USDT")
+
+        # Execute with explicit guardrail check
+        result = await executor.execute_guarded(
+            "place_order",
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1
+        )
+    """
+
+    def __init__(
+        self,
+        toolkit: TradingToolkit | None = None,
+        max_executions_per_minute: int = 30,
+    ):
+        """Initialize the tool executor.
+
+        Args:
+            toolkit: Trading toolkit with registered tools. Uses global if None.
+            max_executions_per_minute: Rate limit for tool executions.
+        """
+        self.toolkit = toolkit or get_trading_toolkit()
+        self.max_executions_per_minute = max_executions_per_minute
+        self._event_bus = get_event_bus()
+        self._stats = ExecutorStats()
+        self._execution_history: list[ExecutionRecord] = []
+        self._recent_executions: list[datetime] = []
+
+    async def execute(
+        self,
+        tool_name: str,
+        skip_guardrails: bool = False,
+        **kwargs: Any,
+    ) -> ToolResult:
+        """Execute a tool by name with automatic guardrail checking.
+
+        For guarded tools (execution category), this will:
+        1. Validate parameters
+        2. Check guardrails before execution
+        3. Execute the tool
+        4. Log and publish events
+
+        Args:
+            tool_name: Name of the tool to execute
+            skip_guardrails: Skip guardrail check (DANGEROUS - use with caution)
+            **kwargs: Parameters to pass to the tool
+
+        Returns:
+            ToolResult from the tool execution
+        """
+        # Check rate limit
+        if not self._check_rate_limit():
+            return ToolResult(
+                success=False,
+                error="Rate limit exceeded. Too many tool executions.",
+                metadata={"rate_limit": self.max_executions_per_minute},
+            )
+
+        # Get the tool
+        tool = self.toolkit.get_tool(tool_name)
+        if tool is None:
+            return ToolResult(
+                success=False,
+                error=f"Tool '{tool_name}' not found",
+            )
+
+        # Record start time
+        started_at = datetime.now(UTC)
+        guardrail_passed = None
+
+        try:
+            # Validate parameters
+            is_valid, error = tool.validate_parameters(**kwargs)
+            if not is_valid:
+                return ToolResult(success=False, error=error)
+
+            # Check guardrails for execution tools
+            if tool.is_guarded and not skip_guardrails:
+                guardrail_result = await self._check_guardrails(tool, kwargs)
+                guardrail_passed = guardrail_result.success
+
+                if not guardrail_result.success:
+                    self._stats.blocked_by_guardrails += 1
+                    await self._publish_event(
+                        "tool.blocked",
+                        tool_name=tool_name,
+                        reason=guardrail_result.error,
+                    )
+                    return guardrail_result
+
+            # Publish execution started event
+            await self._publish_event(
+                "tool.started",
+                tool_name=tool_name,
+                category=tool.category.value,
+                parameters=self._sanitize_params(kwargs),
+            )
+
+            # Execute the tool
+            result = await tool.execute(**kwargs)
+
+            # Record completion
+            completed_at = datetime.now(UTC)
+            duration_ms = (completed_at - started_at).total_seconds() * 1000
+
+            # Update stats
+            self._update_stats(tool, result)
+            self._recent_executions.append(completed_at)
+
+            # Record execution
+            record = ExecutionRecord(
+                tool_name=tool_name,
+                category=tool.category,
+                parameters=self._sanitize_params(kwargs),
+                result=result,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_ms=duration_ms,
+                was_guarded=tool.is_guarded,
+                guardrail_passed=guardrail_passed,
+            )
+            self._execution_history.append(record)
+
+            # Trim history to last 1000 records
+            if len(self._execution_history) > 1000:
+                self._execution_history = self._execution_history[-1000:]
+
+            # Publish completion event
+            await self._publish_event(
+                "tool.completed",
+                tool_name=tool_name,
+                success=result.success,
+                duration_ms=duration_ms,
+            )
+
+            logger.info(
+                "tool_executed",
+                tool=tool_name,
+                category=tool.category.value,
+                success=result.success,
+                duration_ms=duration_ms,
+                guarded=tool.is_guarded,
+            )
+
+            return result
+
+        except Exception as e:
+            self._stats.total_executions += 1
+            self._stats.failed_executions += 1
+
+            await self._publish_event(
+                "tool.failed",
+                tool_name=tool_name,
+                error=str(e),
+            )
+
+            logger.error("tool_execution_error", tool=tool_name, error=str(e))
+
+            return ToolResult(
+                success=False,
+                error=f"Tool execution failed: {str(e)}",
+            )
+
+    async def execute_guarded(
+        self,
+        tool_name: str,
+        **kwargs: Any,
+    ) -> ToolResult:
+        """Execute a guarded tool with explicit guardrail checking.
+
+        This method is specifically for execution tools and will always
+        check guardrails regardless of the skip_guardrails flag.
+
+        Args:
+            tool_name: Name of the tool to execute
+            **kwargs: Parameters to pass to the tool
+
+        Returns:
+            ToolResult from the tool execution
+        """
+        tool = self.toolkit.get_tool(tool_name)
+        if tool is None:
+            return ToolResult(success=False, error=f"Tool '{tool_name}' not found")
+
+        if not tool.is_guarded:
+            logger.warning(
+                "execute_guarded_on_unguarded_tool",
+                tool=tool_name,
+                category=tool.category.value,
+            )
+
+        return await self.execute(tool_name, skip_guardrails=False, **kwargs)
+
+    async def _check_guardrails(
+        self,
+        tool: BaseTool,
+        params: dict[str, Any],
+    ) -> ToolResult:
+        """Check guardrails before executing a guarded tool.
+
+        Args:
+            tool: The tool being executed
+            params: Tool parameters
+
+        Returns:
+            ToolResult indicating whether guardrails passed
+        """
+        # Only check for order placement tool
+        if tool.name == "place_order":
+            from keryxflow.aegis.guardrails import get_guardrail_enforcer
+            from keryxflow.aegis.risk import get_risk_manager
+
+            symbol = params.get("symbol")
+            side = params.get("side")
+            quantity = params.get("quantity")
+            stop_loss = params.get("stop_loss")
+
+            if not all([symbol, side, quantity]):
+                return ToolResult(
+                    success=False,
+                    error="Missing required parameters for guardrail check",
+                )
+
+            # Get current price for validation
+            price = params.get("price")
+            if price is None:
+                from keryxflow.exchange.paper import get_paper_engine
+
+                engine = get_paper_engine()
+                price = engine.get_price(symbol)
+
+            if price is None:
+                # Can't validate without price, let the tool handle it
+                return ToolResult(success=True)
+
+            risk_manager = get_risk_manager()
+            enforcer = get_guardrail_enforcer()
+
+            result = enforcer.validate_order(
+                symbol=symbol,
+                side=side,
+                quantity=quantity,
+                entry_price=price,
+                stop_loss=stop_loss,
+                portfolio=risk_manager.portfolio_state,
+            )
+
+            if not result.allowed:
+                return ToolResult(
+                    success=False,
+                    error=f"Guardrail violation: {result.message}",
+                    metadata={
+                        "violation": result.violation.value if result.violation else None,
+                        "details": result.details,
+                    },
+                )
+
+        # For other execution tools, allow by default
+        # (they have their own internal validation)
+        return ToolResult(success=True)
+
+    def _check_rate_limit(self) -> bool:
+        """Check if we're within rate limits.
+
+        Returns:
+            True if within limits, False if exceeded
+        """
+        now = datetime.now(UTC)
+
+        # Remove entries older than 1 minute
+        self._recent_executions = [
+            t for t in self._recent_executions if (now - t).total_seconds() < 60
+        ]
+
+        return len(self._recent_executions) < self.max_executions_per_minute
+
+    def _update_stats(self, tool: BaseTool, result: ToolResult) -> None:
+        """Update execution statistics.
+
+        Args:
+            tool: The executed tool
+            result: The execution result
+        """
+        self._stats.total_executions += 1
+        self._stats.last_execution_time = datetime.now(UTC)
+
+        if result.success:
+            self._stats.successful_executions += 1
+        else:
+            self._stats.failed_executions += 1
+
+        category = tool.category.value
+        if category not in self._stats.executions_by_category:
+            self._stats.executions_by_category[category] = 0
+        self._stats.executions_by_category[category] += 1
+
+    async def _publish_event(self, event_type: str, **data: Any) -> None:
+        """Publish a tool execution event.
+
+        Args:
+            event_type: Type of event (e.g., "tool.started")
+            **data: Event data
+        """
+        event = Event(
+            type=EventType.SYSTEM_STARTED,  # Using as generic event
+            data={"event_type": event_type, **data},
+        )
+        await self._event_bus.publish(event)
+
+    def _sanitize_params(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Sanitize parameters for logging (remove sensitive data).
+
+        Args:
+            params: Original parameters
+
+        Returns:
+            Sanitized parameters safe for logging
+        """
+        sanitized = {}
+        sensitive_keys = {"api_key", "secret", "password", "token"}
+
+        for key, value in params.items():
+            if key.lower() in sensitive_keys:
+                sanitized[key] = "***"
+            else:
+                sanitized[key] = value
+
+        return sanitized
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get executor statistics.
+
+        Returns:
+            Dictionary with execution statistics
+        """
+        return {
+            "total_executions": self._stats.total_executions,
+            "successful_executions": self._stats.successful_executions,
+            "failed_executions": self._stats.failed_executions,
+            "blocked_by_guardrails": self._stats.blocked_by_guardrails,
+            "executions_by_category": self._stats.executions_by_category,
+            "success_rate": (
+                self._stats.successful_executions / self._stats.total_executions
+                if self._stats.total_executions > 0
+                else 0
+            ),
+            "last_execution_time": (
+                self._stats.last_execution_time.isoformat()
+                if self._stats.last_execution_time
+                else None
+            ),
+        }
+
+    def get_recent_executions(self, limit: int = 10) -> list[dict[str, Any]]:
+        """Get recent tool executions.
+
+        Args:
+            limit: Maximum number of executions to return
+
+        Returns:
+            List of recent execution records
+        """
+        records = self._execution_history[-limit:]
+        return [
+            {
+                "tool_name": r.tool_name,
+                "category": r.category.value,
+                "success": r.result.success,
+                "error": r.result.error if not r.result.success else None,
+                "duration_ms": r.duration_ms,
+                "was_guarded": r.was_guarded,
+                "guardrail_passed": r.guardrail_passed,
+                "started_at": r.started_at.isoformat(),
+            }
+            for r in reversed(records)
+        ]
+
+    def clear_stats(self) -> None:
+        """Clear execution statistics."""
+        self._stats = ExecutorStats()
+        self._execution_history = []
+        self._recent_executions = []
+
+
+# Global executor instance
+_executor: ToolExecutor | None = None
+
+
+def get_tool_executor() -> ToolExecutor:
+    """Get the global tool executor instance."""
+    global _executor
+    if _executor is None:
+        _executor = ToolExecutor()
+    return _executor

--- a/keryxflow/agent/perception_tools.py
+++ b/keryxflow/agent/perception_tools.py
@@ -1,0 +1,589 @@
+"""Perception tools for market data and portfolio state.
+
+These tools are READ-ONLY and do not require guardrail validation.
+They allow the agent to perceive the current market state.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from keryxflow.agent.tools import (
+    BaseTool,
+    ToolCategory,
+    ToolParameter,
+    ToolResult,
+    TradingToolkit,
+)
+from keryxflow.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class GetCurrentPriceTool(BaseTool):
+    """Get the current price for a trading pair."""
+
+    @property
+    def name(self) -> str:
+        return "get_current_price"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get the current market price for a cryptocurrency trading pair. "
+            "Returns the latest price from the exchange or paper trading engine."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.PERCEPTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol (e.g., 'BTC/USDT', 'ETH/USDT')",
+                required=True,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs["symbol"]
+
+        try:
+            from keryxflow.exchange.orders import get_order_manager
+
+            order_manager = get_order_manager()
+            await order_manager.initialize()
+
+            # Try to get from paper engine first
+            if order_manager.is_paper_mode:
+                from keryxflow.exchange.paper import get_paper_engine
+
+                engine = get_paper_engine()
+                price = engine.get_price(symbol)
+
+                if price is not None:
+                    return ToolResult(
+                        success=True,
+                        data={
+                            "symbol": symbol,
+                            "price": price,
+                            "timestamp": datetime.now(UTC).isoformat(),
+                            "source": "paper_engine",
+                        },
+                    )
+
+            # Fall back to fetching from exchange
+            from keryxflow.exchange.client import get_exchange_client
+
+            client = get_exchange_client()
+            ticker = await client.fetch_ticker(symbol)
+
+            return ToolResult(
+                success=True,
+                data={
+                    "symbol": symbol,
+                    "price": ticker.get("last", ticker.get("close")),
+                    "bid": ticker.get("bid"),
+                    "ask": ticker.get("ask"),
+                    "volume_24h": ticker.get("quoteVolume"),
+                    "change_24h": ticker.get("percentage"),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "source": "exchange",
+                },
+            )
+
+        except Exception as e:
+            logger.error("get_current_price_failed", symbol=symbol, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to get price for {symbol}: {str(e)}",
+            )
+
+
+class GetOHLCVTool(BaseTool):
+    """Get OHLCV (candlestick) data for a trading pair."""
+
+    @property
+    def name(self) -> str:
+        return "get_ohlcv"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get historical OHLCV (Open, High, Low, Close, Volume) candlestick data "
+            "for a trading pair. Useful for technical analysis."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.PERCEPTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol (e.g., 'BTC/USDT')",
+                required=True,
+            ),
+            ToolParameter(
+                name="timeframe",
+                type="string",
+                description="Candlestick timeframe",
+                required=False,
+                default="1h",
+                enum=["1m", "5m", "15m", "30m", "1h", "4h", "1d"],
+            ),
+            ToolParameter(
+                name="limit",
+                type="integer",
+                description="Number of candles to fetch (max 500)",
+                required=False,
+                default=100,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs["symbol"]
+        timeframe = kwargs.get("timeframe", "1h")
+        limit = min(kwargs.get("limit", 100), 500)
+
+        try:
+            from keryxflow.exchange.client import get_exchange_client
+
+            client = get_exchange_client()
+            ohlcv = await client.fetch_ohlcv(symbol, timeframe, limit=limit)
+
+            # Format the data
+            candles = []
+            for candle in ohlcv:
+                candles.append(
+                    {
+                        "timestamp": datetime.fromtimestamp(candle[0] / 1000, tz=UTC).isoformat(),
+                        "open": candle[1],
+                        "high": candle[2],
+                        "low": candle[3],
+                        "close": candle[4],
+                        "volume": candle[5],
+                    }
+                )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "candles": candles,
+                    "count": len(candles),
+                },
+            )
+
+        except Exception as e:
+            logger.error("get_ohlcv_failed", symbol=symbol, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to get OHLCV for {symbol}: {str(e)}",
+            )
+
+
+class GetOrderBookTool(BaseTool):
+    """Get order book depth for a trading pair."""
+
+    @property
+    def name(self) -> str:
+        return "get_order_book"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get the current order book (bids and asks) for a trading pair. "
+            "Shows market depth and liquidity."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.PERCEPTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Trading pair symbol (e.g., 'BTC/USDT')",
+                required=True,
+            ),
+            ToolParameter(
+                name="limit",
+                type="integer",
+                description="Number of price levels to fetch (max 100)",
+                required=False,
+                default=20,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs["symbol"]
+        limit = min(kwargs.get("limit", 20), 100)
+
+        try:
+            from keryxflow.exchange.client import get_exchange_client
+
+            client = get_exchange_client()
+            order_book = await client.fetch_order_book(symbol, limit=limit)
+
+            # Calculate metrics
+            bids = order_book.get("bids", [])[:limit]
+            asks = order_book.get("asks", [])[:limit]
+
+            total_bid_volume = sum(b[1] for b in bids) if bids else 0
+            total_ask_volume = sum(a[1] for a in asks) if asks else 0
+
+            best_bid = bids[0][0] if bids else None
+            best_ask = asks[0][0] if asks else None
+            spread = (best_ask - best_bid) if best_bid and best_ask else None
+            spread_pct = (spread / best_bid * 100) if spread and best_bid else None
+
+            return ToolResult(
+                success=True,
+                data={
+                    "symbol": symbol,
+                    "bids": [{"price": b[0], "quantity": b[1]} for b in bids],
+                    "asks": [{"price": a[0], "quantity": a[1]} for a in asks],
+                    "best_bid": best_bid,
+                    "best_ask": best_ask,
+                    "spread": spread,
+                    "spread_pct": spread_pct,
+                    "total_bid_volume": total_bid_volume,
+                    "total_ask_volume": total_ask_volume,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("get_order_book_failed", symbol=symbol, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to get order book for {symbol}: {str(e)}",
+            )
+
+
+class GetPortfolioStateTool(BaseTool):
+    """Get the current portfolio state including positions and exposure."""
+
+    @property
+    def name(self) -> str:
+        return "get_portfolio_state"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get the current portfolio state including total value, cash, "
+            "open positions, exposure, and risk metrics."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.PERCEPTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return []  # No parameters needed
+
+    async def execute(self, **kwargs: Any) -> ToolResult:  # noqa: ARG002
+        try:
+            from keryxflow.aegis.risk import get_risk_manager
+
+            risk_manager = get_risk_manager()
+            portfolio = risk_manager.portfolio_state
+
+            # Get positions data
+            positions_data = []
+            for pos in portfolio.positions:
+                positions_data.append(
+                    {
+                        "symbol": pos.symbol,
+                        "side": pos.side,
+                        "quantity": float(pos.quantity),
+                        "entry_price": float(pos.entry_price),
+                        "current_price": float(pos.current_price),
+                        "unrealized_pnl": float(pos.unrealized_pnl),
+                        "unrealized_pnl_pct": float(pos.unrealized_pnl_pct) * 100,
+                        "stop_loss": float(pos.stop_loss) if pos.stop_loss else None,
+                        "take_profit": float(pos.take_profit) if pos.take_profit else None,
+                    }
+                )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "total_value": float(portfolio.total_value),
+                    "cash_available": float(portfolio.cash_available),
+                    "total_exposure": float(portfolio.total_exposure),
+                    "exposure_pct": float(portfolio.exposure_pct) * 100,
+                    "cash_reserve_pct": float(portfolio.cash_reserve_pct) * 100,
+                    "unrealized_pnl": float(portfolio.unrealized_pnl),
+                    "daily_pnl": float(portfolio.daily_pnl),
+                    "drawdown_pct": float(portfolio.drawdown_pct) * 100,
+                    "position_count": portfolio.position_count,
+                    "positions": positions_data,
+                    "consecutive_losses": portfolio.consecutive_losses,
+                    "trades_today": portfolio.trades_today,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("get_portfolio_state_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to get portfolio state: {str(e)}",
+            )
+
+
+class GetBalanceTool(BaseTool):
+    """Get the current account balance."""
+
+    @property
+    def name(self) -> str:
+        return "get_balance"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get the current account balance showing total, free (available), "
+            "and used (in orders/positions) amounts for each currency."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.PERCEPTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="currency",
+                type="string",
+                description="Specific currency to get balance for (optional, returns all if not specified)",
+                required=False,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        currency = kwargs.get("currency")
+
+        try:
+            from keryxflow.exchange.orders import get_order_manager
+
+            order_manager = get_order_manager()
+            await order_manager.initialize()
+            balance = await order_manager.get_balance()
+
+            if currency:
+                total = balance.get("total", {}).get(currency, 0)
+                free = balance.get("free", {}).get(currency, 0)
+                used = balance.get("used", {}).get(currency, 0)
+
+                return ToolResult(
+                    success=True,
+                    data={
+                        "currency": currency,
+                        "total": total,
+                        "free": free,
+                        "used": used,
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    },
+                )
+            else:
+                return ToolResult(
+                    success=True,
+                    data={
+                        "total": balance.get("total", {}),
+                        "free": balance.get("free", {}),
+                        "used": balance.get("used", {}),
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    },
+                )
+
+        except Exception as e:
+            logger.error("get_balance_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to get balance: {str(e)}",
+            )
+
+
+class GetPositionsTool(BaseTool):
+    """Get all open positions."""
+
+    @property
+    def name(self) -> str:
+        return "get_positions"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get all currently open trading positions with their entry prices, "
+            "current prices, unrealized P&L, and stop/take profit levels."
+        )
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.PERCEPTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Filter by specific symbol (optional)",
+                required=False,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs.get("symbol")
+
+        try:
+            from keryxflow.exchange.paper import get_paper_engine
+
+            engine = get_paper_engine()
+            await engine.initialize()
+
+            if symbol:
+                position = await engine.get_position(symbol)
+                positions = [position] if position else []
+            else:
+                positions = await engine.get_positions()
+
+            positions_data = []
+            for pos in positions:
+                positions_data.append(
+                    {
+                        "id": pos.id,
+                        "symbol": pos.symbol,
+                        "side": pos.side.value,
+                        "quantity": pos.quantity,
+                        "entry_price": pos.entry_price,
+                        "current_price": pos.current_price,
+                        "unrealized_pnl": pos.unrealized_pnl,
+                        "unrealized_pnl_pct": pos.unrealized_pnl_percentage,
+                        "stop_loss": pos.stop_loss,
+                        "take_profit": pos.take_profit,
+                        "opened_at": pos.opened_at.isoformat() if pos.opened_at else None,
+                    }
+                )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "positions": positions_data,
+                    "count": len(positions_data),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("get_positions_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to get positions: {str(e)}",
+            )
+
+
+class GetOpenOrdersTool(BaseTool):
+    """Get all open (pending) orders."""
+
+    @property
+    def name(self) -> str:
+        return "get_open_orders"
+
+    @property
+    def description(self) -> str:
+        return "Get all open (pending) orders that have not yet been filled."
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.PERCEPTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [
+            ToolParameter(
+                name="symbol",
+                type="string",
+                description="Filter by specific symbol (optional)",
+                required=False,
+            ),
+        ]
+
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        symbol = kwargs.get("symbol")
+
+        try:
+            from keryxflow.exchange.orders import get_order_manager
+
+            order_manager = get_order_manager()
+            await order_manager.initialize()
+            orders = await order_manager.get_open_orders(symbol)
+
+            orders_data = []
+            for order in orders:
+                orders_data.append(
+                    {
+                        "id": order.id,
+                        "symbol": order.symbol,
+                        "type": order.order_type.value,
+                        "side": order.side,
+                        "amount": order.amount,
+                        "price": order.price,
+                        "filled": order.filled,
+                        "remaining": order.remaining,
+                        "status": order.status.value,
+                        "created_at": order.created_at.isoformat() if order.created_at else None,
+                    }
+                )
+
+            return ToolResult(
+                success=True,
+                data={
+                    "orders": orders_data,
+                    "count": len(orders_data),
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+            )
+
+        except Exception as e:
+            logger.error("get_open_orders_failed", error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Failed to get open orders: {str(e)}",
+            )
+
+
+def register_perception_tools(toolkit: TradingToolkit) -> None:
+    """Register all perception tools with the toolkit.
+
+    Args:
+        toolkit: The toolkit to register tools with
+    """
+    tools = [
+        GetCurrentPriceTool(),
+        GetOHLCVTool(),
+        GetOrderBookTool(),
+        GetPortfolioStateTool(),
+        GetBalanceTool(),
+        GetPositionsTool(),
+        GetOpenOrdersTool(),
+    ]
+
+    for tool in tools:
+        toolkit.register(tool)
+
+    logger.info("perception_tools_registered", count=len(tools))

--- a/keryxflow/agent/tools.py
+++ b/keryxflow/agent/tools.py
@@ -1,0 +1,419 @@
+"""Agent tool framework for AI-first trading.
+
+This module provides the base framework for creating tools that can be used
+by the cognitive agent. Tools are compatible with Anthropic's Tool Use API.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from keryxflow.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ToolCategory(str, Enum):
+    """Categories of agent tools."""
+
+    PERCEPTION = "perception"  # Read-only market data
+    ANALYSIS = "analysis"  # Computation and analysis
+    INTROSPECTION = "introspection"  # Memory and rules
+    EXECUTION = "execution"  # Order execution (GUARDED)
+
+
+@dataclass
+class ToolParameter:
+    """Definition of a tool parameter."""
+
+    name: str
+    type: str  # "string", "number", "integer", "boolean", "array", "object"
+    description: str
+    required: bool = True
+    enum: list[str] | None = None
+    default: Any = None
+    items: dict[str, Any] | None = None  # For array types
+
+
+@dataclass
+class ToolResult:
+    """Result of a tool execution."""
+
+    success: bool
+    data: Any = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for API response."""
+        result = {"success": self.success}
+        if self.success:
+            result["data"] = self.data
+        else:
+            result["error"] = self.error
+        if self.metadata:
+            result["metadata"] = self.metadata
+        return result
+
+
+class BaseTool(ABC):
+    """Abstract base class for all agent tools.
+
+    Tools must implement:
+    - name: Unique identifier for the tool
+    - description: What the tool does (for LLM)
+    - category: Tool category (perception, analysis, execution, etc.)
+    - parameters: List of ToolParameter definitions
+    - execute(): Async method that performs the tool's action
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique name of the tool."""
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Description of what the tool does."""
+        ...
+
+    @property
+    @abstractmethod
+    def category(self) -> ToolCategory:
+        """Category of the tool."""
+        ...
+
+    @property
+    @abstractmethod
+    def parameters(self) -> list[ToolParameter]:
+        """List of parameters the tool accepts."""
+        ...
+
+    @property
+    def is_guarded(self) -> bool:
+        """Whether the tool requires guardrail validation."""
+        return self.category == ToolCategory.EXECUTION
+
+    @abstractmethod
+    async def execute(self, **kwargs: Any) -> ToolResult:
+        """Execute the tool with the given parameters.
+
+        Args:
+            **kwargs: Tool parameters as keyword arguments
+
+        Returns:
+            ToolResult with success status and data or error
+        """
+        ...
+
+    def to_anthropic_schema(self) -> dict[str, Any]:
+        """Convert tool to Anthropic Tool Use API format.
+
+        Returns a schema compatible with:
+        https://docs.anthropic.com/en/docs/tool-use
+        """
+        properties = {}
+        required = []
+
+        for param in self.parameters:
+            prop: dict[str, Any] = {
+                "type": param.type,
+                "description": param.description,
+            }
+
+            if param.enum:
+                prop["enum"] = param.enum
+
+            if param.items:
+                prop["items"] = param.items
+
+            if param.default is not None:
+                prop["default"] = param.default
+
+            properties[param.name] = prop
+
+            if param.required:
+                required.append(param.name)
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": {
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            },
+        }
+
+    def validate_parameters(self, **kwargs: Any) -> tuple[bool, str | None]:
+        """Validate that required parameters are provided.
+
+        Returns:
+            Tuple of (is_valid, error_message)
+        """
+        for param in self.parameters:
+            if param.required and param.name not in kwargs:
+                return False, f"Missing required parameter: {param.name}"
+
+            if param.name in kwargs:
+                value = kwargs[param.name]
+                # Type validation
+                if param.type == "string" and not isinstance(value, str):
+                    return False, f"Parameter {param.name} must be a string"
+                elif param.type == "number" and not isinstance(value, int | float):
+                    return False, f"Parameter {param.name} must be a number"
+                elif param.type == "integer" and not isinstance(value, int):
+                    return False, f"Parameter {param.name} must be an integer"
+                elif param.type == "boolean" and not isinstance(value, bool):
+                    return False, f"Parameter {param.name} must be a boolean"
+                elif param.type == "array" and not isinstance(value, list):
+                    return False, f"Parameter {param.name} must be an array"
+
+                # Enum validation
+                if param.enum and value not in param.enum:
+                    return False, f"Parameter {param.name} must be one of: {param.enum}"
+
+        return True, None
+
+
+class TradingToolkit:
+    """Registry and manager for trading tools.
+
+    The toolkit manages all available tools and provides methods to:
+    - Register tools
+    - Get tool schemas for the LLM
+    - Execute tools by name
+    """
+
+    def __init__(self) -> None:
+        """Initialize the toolkit."""
+        self._tools: dict[str, BaseTool] = {}
+        self._tools_by_category: dict[ToolCategory, list[BaseTool]] = {
+            category: [] for category in ToolCategory
+        }
+
+    def register(self, tool: BaseTool) -> None:
+        """Register a tool with the toolkit.
+
+        Args:
+            tool: Tool instance to register
+
+        Raises:
+            ValueError: If a tool with the same name is already registered
+        """
+        if tool.name in self._tools:
+            raise ValueError(f"Tool '{tool.name}' is already registered")
+
+        self._tools[tool.name] = tool
+        self._tools_by_category[tool.category].append(tool)
+
+        logger.debug("tool_registered", name=tool.name, category=tool.category.value)
+
+    def get_tool(self, name: str) -> BaseTool | None:
+        """Get a tool by name.
+
+        Args:
+            name: Name of the tool
+
+        Returns:
+            Tool instance or None if not found
+        """
+        return self._tools.get(name)
+
+    def get_tools_by_category(self, category: ToolCategory) -> list[BaseTool]:
+        """Get all tools in a category.
+
+        Args:
+            category: Tool category
+
+        Returns:
+            List of tools in the category
+        """
+        return self._tools_by_category[category].copy()
+
+    def get_all_tools(self) -> list[BaseTool]:
+        """Get all registered tools.
+
+        Returns:
+            List of all tools
+        """
+        return list(self._tools.values())
+
+    def get_guarded_tools(self) -> list[BaseTool]:
+        """Get all tools that require guardrail validation.
+
+        Returns:
+            List of guarded tools (execution tools)
+        """
+        return [tool for tool in self._tools.values() if tool.is_guarded]
+
+    def get_anthropic_tools_schema(
+        self, categories: list[ToolCategory] | None = None
+    ) -> list[dict[str, Any]]:
+        """Get tool schemas in Anthropic Tool Use API format.
+
+        Args:
+            categories: Optional list of categories to include.
+                       If None, all categories are included.
+
+        Returns:
+            List of tool schemas for the API
+        """
+        tools = []
+
+        for tool in self._tools.values():
+            if categories is None or tool.category in categories:
+                tools.append(tool.to_anthropic_schema())
+
+        return tools
+
+    async def execute(self, tool_name: str, **kwargs: Any) -> ToolResult:
+        """Execute a tool by name.
+
+        Note: This method does NOT perform guardrail validation.
+        Use ToolExecutor for guarded execution.
+
+        Args:
+            tool_name: Name of the tool to execute
+            **kwargs: Tool parameters
+
+        Returns:
+            ToolResult from the tool execution
+        """
+        tool = self.get_tool(tool_name)
+        if tool is None:
+            return ToolResult(
+                success=False,
+                error=f"Tool '{tool_name}' not found",
+            )
+
+        # Validate parameters
+        is_valid, error = tool.validate_parameters(**kwargs)
+        if not is_valid:
+            return ToolResult(
+                success=False,
+                error=error,
+            )
+
+        try:
+            result = await tool.execute(**kwargs)
+            logger.info(
+                "tool_executed",
+                tool=tool_name,
+                success=result.success,
+                category=tool.category.value,
+            )
+            return result
+        except Exception as e:
+            logger.error("tool_execution_failed", tool=tool_name, error=str(e))
+            return ToolResult(
+                success=False,
+                error=f"Tool execution failed: {str(e)}",
+            )
+
+    def list_tools(self) -> dict[str, list[str]]:
+        """List all tools grouped by category.
+
+        Returns:
+            Dictionary mapping category names to tool names
+        """
+        return {
+            category.value: [tool.name for tool in tools]
+            for category, tools in self._tools_by_category.items()
+            if tools
+        }
+
+    @property
+    def tool_count(self) -> int:
+        """Get the number of registered tools."""
+        return len(self._tools)
+
+
+def create_tool(
+    name: str,
+    description: str,
+    category: ToolCategory,
+    parameters: list[ToolParameter],
+):
+    """Decorator to create a tool from an async function.
+
+    Example:
+        @create_tool(
+            name="get_price",
+            description="Get current price for a symbol",
+            category=ToolCategory.PERCEPTION,
+            parameters=[
+                ToolParameter("symbol", "string", "Trading pair symbol", required=True)
+            ]
+        )
+        async def get_price(symbol: str) -> ToolResult:
+            price = await fetch_price(symbol)
+            return ToolResult(success=True, data={"price": price})
+    """
+
+    def decorator(func):
+        class FunctionalTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return name
+
+            @property
+            def description(self) -> str:
+                return description
+
+            @property
+            def category(self) -> ToolCategory:
+                return category
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return parameters
+
+            async def execute(self, **kwargs: Any) -> ToolResult:
+                return await func(**kwargs)
+
+        return FunctionalTool()
+
+    return decorator
+
+
+# Global toolkit instance
+_toolkit: TradingToolkit | None = None
+
+
+def get_trading_toolkit() -> TradingToolkit:
+    """Get the global trading toolkit instance."""
+    global _toolkit
+    if _toolkit is None:
+        _toolkit = TradingToolkit()
+    return _toolkit
+
+
+def register_all_tools(toolkit: TradingToolkit | None = None) -> TradingToolkit:
+    """Register all available tools with the toolkit.
+
+    Args:
+        toolkit: Toolkit to register tools with. If None, uses global toolkit.
+
+    Returns:
+        The toolkit with all tools registered
+    """
+    if toolkit is None:
+        toolkit = get_trading_toolkit()
+
+    # Import and register tools from each module
+    # These imports trigger tool registration
+    from keryxflow.agent.analysis_tools import register_analysis_tools
+    from keryxflow.agent.execution_tools import register_execution_tools
+    from keryxflow.agent.perception_tools import register_perception_tools
+
+    register_perception_tools(toolkit)
+    register_analysis_tools(toolkit)
+    register_execution_tools(toolkit)
+
+    logger.info("all_tools_registered", count=toolkit.tool_count)
+
+    return toolkit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "keryxflow"
-version = "0.12.0"
+version = "0.13.0"
 description = "A hybrid AI & quantitative trading engine for cryptocurrency markets"
 authors = ["KeryxFlow Contributors"]
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,9 @@ def setup_test_database(tmp_path):
     import keryxflow.memory.episodic as episodic_module
     import keryxflow.memory.manager as manager_module
     import keryxflow.memory.semantic as semantic_module
+    import keryxflow.agent.tools as tools_module
+    import keryxflow.agent.executor as executor_module
+    import keryxflow.aegis.risk as risk_module
 
     config_module._settings = None
     db_module._engine = None
@@ -31,6 +34,9 @@ def setup_test_database(tmp_path):
     episodic_module._episodic_memory = None
     semantic_module._semantic_memory = None
     manager_module._memory_manager = None
+    tools_module._toolkit = None
+    executor_module._executor = None
+    risk_module._risk_manager = None
 
     yield
 

--- a/tests/test_agent/__init__.py
+++ b/tests/test_agent/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the agent module."""

--- a/tests/test_agent/test_analysis.py
+++ b/tests/test_agent/test_analysis.py
@@ -1,0 +1,369 @@
+"""Tests for analysis tools."""
+
+import pytest
+
+from keryxflow.agent.analysis_tools import (
+    CalculateIndicatorsTool,
+    CalculatePositionSizeTool,
+    CalculateRiskRewardTool,
+    CalculateStopLossTool,
+    GetMarketPatternsTool,
+    GetTradingRulesTool,
+    RecallSimilarTradesTool,
+    register_analysis_tools,
+)
+from keryxflow.agent.tools import ToolCategory, TradingToolkit
+
+
+class TestAnalysisToolsRegistration:
+    """Tests for analysis tools registration."""
+
+    def test_register_analysis_tools(self):
+        """Test registering all analysis tools."""
+        toolkit = TradingToolkit()
+        register_analysis_tools(toolkit)
+
+        # Should have 7 analysis/introspection tools
+        analysis_tools = toolkit.get_tools_by_category(ToolCategory.ANALYSIS)
+        introspection_tools = toolkit.get_tools_by_category(ToolCategory.INTROSPECTION)
+
+        assert len(analysis_tools) == 4  # indicators, position_size, risk_reward, stop_loss
+        assert len(introspection_tools) == 3  # rules, similar_trades, patterns
+
+    def test_analysis_tools_not_guarded(self):
+        """Test that analysis tools are not guarded."""
+        toolkit = TradingToolkit()
+        register_analysis_tools(toolkit)
+
+        all_tools = (
+            toolkit.get_tools_by_category(ToolCategory.ANALYSIS)
+            + toolkit.get_tools_by_category(ToolCategory.INTROSPECTION)
+        )
+
+        for tool in all_tools:
+            assert tool.is_guarded is False
+
+
+class TestCalculateIndicatorsTool:
+    """Tests for CalculateIndicatorsTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = CalculateIndicatorsTool()
+
+        assert tool.name == "calculate_indicators"
+        assert tool.category == ToolCategory.ANALYSIS
+        assert tool.is_guarded is False
+
+    def test_parameters(self):
+        """Test tool parameters."""
+        tool = CalculateIndicatorsTool()
+
+        assert len(tool.parameters) == 3
+
+        symbol_param = next(p for p in tool.parameters if p.name == "symbol")
+        assert symbol_param.required is True
+
+        timeframe_param = next(p for p in tool.parameters if p.name == "timeframe")
+        assert timeframe_param.default == "1h"
+        assert "4h" in timeframe_param.enum
+
+
+class TestCalculatePositionSizeTool:
+    """Tests for CalculatePositionSizeTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = CalculatePositionSizeTool()
+
+        assert tool.name == "calculate_position_size"
+        assert tool.category == ToolCategory.ANALYSIS
+
+    def test_parameters(self):
+        """Test tool parameters."""
+        tool = CalculatePositionSizeTool()
+
+        param_names = [p.name for p in tool.parameters]
+        assert "balance" in param_names
+        assert "entry_price" in param_names
+        assert "stop_loss" in param_names
+        assert "risk_pct" in param_names
+
+    @pytest.mark.asyncio
+    async def test_execute_calculates_position_size(self):
+        """Test position size calculation."""
+        tool = CalculatePositionSizeTool()
+
+        result = await tool.execute(
+            balance=10000.0,
+            entry_price=45000.0,
+            stop_loss=44000.0,
+            risk_pct=0.01,  # 1% risk
+        )
+
+        assert result.success is True
+        assert "quantity" in result.data
+        assert "risk_amount" in result.data
+        assert result.data["risk_amount"] <= 100.0  # 1% of 10000
+
+    @pytest.mark.asyncio
+    async def test_execute_with_invalid_stop_loss(self):
+        """Test with stop loss equal to entry (invalid)."""
+        tool = CalculatePositionSizeTool()
+
+        result = await tool.execute(
+            balance=10000.0,
+            entry_price=45000.0,
+            stop_loss=45000.0,  # Same as entry
+            risk_pct=0.01,
+        )
+
+        assert result.success is False
+
+
+class TestCalculateRiskRewardTool:
+    """Tests for CalculateRiskRewardTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = CalculateRiskRewardTool()
+
+        assert tool.name == "calculate_risk_reward"
+        assert tool.category == ToolCategory.ANALYSIS
+
+    @pytest.mark.asyncio
+    async def test_execute_calculates_ratio(self):
+        """Test R:R ratio calculation."""
+        tool = CalculateRiskRewardTool()
+
+        result = await tool.execute(
+            entry_price=100.0,
+            stop_loss=95.0,  # Risk 5
+            take_profit=110.0,  # Reward 10
+            quantity=10.0,
+        )
+
+        assert result.success is True
+        assert result.data["ratio"] == 2.0  # 10/5 = 2
+        assert result.data["potential_profit"] == 100.0  # 10 * 10
+        assert result.data["potential_loss"] == 50.0  # 5 * 10
+        assert result.data["is_favorable"] is True
+
+    @pytest.mark.asyncio
+    async def test_unfavorable_ratio(self):
+        """Test calculation of unfavorable R:R."""
+        tool = CalculateRiskRewardTool()
+
+        result = await tool.execute(
+            entry_price=100.0,
+            stop_loss=90.0,  # Risk 10
+            take_profit=105.0,  # Reward 5
+        )
+
+        assert result.success is True
+        assert result.data["ratio"] == 0.5
+        assert result.data["is_favorable"] is False
+
+
+class TestCalculateStopLossTool:
+    """Tests for CalculateStopLossTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = CalculateStopLossTool()
+
+        assert tool.name == "calculate_stop_loss"
+        assert tool.category == ToolCategory.ANALYSIS
+
+    @pytest.mark.asyncio
+    async def test_fixed_stop_loss_buy(self):
+        """Test fixed percentage stop for buy order."""
+        tool = CalculateStopLossTool()
+
+        result = await tool.execute(
+            entry_price=100.0,
+            side="buy",
+            method="fixed",
+            percentage=0.02,  # 2%
+        )
+
+        assert result.success is True
+        assert result.data["stop_loss"] == 98.0  # 100 - 2%
+        assert result.data["method"] == "Fixed 2.0%"
+
+    @pytest.mark.asyncio
+    async def test_fixed_stop_loss_sell(self):
+        """Test fixed percentage stop for sell order."""
+        tool = CalculateStopLossTool()
+
+        result = await tool.execute(
+            entry_price=100.0,
+            side="sell",
+            method="fixed",
+            percentage=0.02,
+        )
+
+        assert result.success is True
+        assert result.data["stop_loss"] == 102.0  # 100 + 2%
+
+    @pytest.mark.asyncio
+    async def test_atr_stop_requires_symbol(self):
+        """Test that ATR stop requires symbol."""
+        tool = CalculateStopLossTool()
+
+        result = await tool.execute(
+            entry_price=100.0,
+            side="buy",
+            method="atr",
+        )
+
+        assert result.success is False
+        assert "Symbol is required" in result.error
+
+
+class TestGetTradingRulesTool:
+    """Tests for GetTradingRulesTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = GetTradingRulesTool()
+
+        assert tool.name == "get_trading_rules"
+        assert tool.category == ToolCategory.INTROSPECTION
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_empty_list(self, init_db):
+        """Test returns empty list when no rules."""
+        tool = GetTradingRulesTool()
+        result = await tool.execute()
+
+        assert result.success is True
+        assert result.data["rules"] == []
+        assert result.data["count"] == 0
+
+
+class TestRecallSimilarTradesTool:
+    """Tests for RecallSimilarTradesTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = RecallSimilarTradesTool()
+
+        assert tool.name == "recall_similar_trades"
+        assert tool.category == ToolCategory.INTROSPECTION
+
+    def test_parameters(self):
+        """Test tool parameters."""
+        tool = RecallSimilarTradesTool()
+
+        param_names = [p.name for p in tool.parameters]
+        assert "symbol" in param_names
+        assert "rsi" in param_names
+        assert "trend" in param_names
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_empty_list(self, init_db):
+        """Test returns empty list when no similar trades."""
+        tool = RecallSimilarTradesTool()
+        result = await tool.execute(symbol="BTC/USDT")
+
+        assert result.success is True
+        assert result.data["similar_trades"] == []
+        assert result.data["count"] == 0
+
+
+class TestGetMarketPatternsTool:
+    """Tests for GetMarketPatternsTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = GetMarketPatternsTool()
+
+        assert tool.name == "get_market_patterns"
+        assert tool.category == ToolCategory.INTROSPECTION
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_empty_list(self, init_db):
+        """Test returns empty list when no patterns."""
+        tool = GetMarketPatternsTool()
+        result = await tool.execute()
+
+        assert result.success is True
+        assert result.data["patterns"] == []
+        assert result.data["count"] == 0
+
+
+class TestAnalysisToolsIntegration:
+    """Integration tests for analysis tools."""
+
+    @pytest.mark.asyncio
+    async def test_tools_can_be_executed_through_toolkit(self, init_db):
+        """Test that analysis tools can be executed through toolkit."""
+        toolkit = TradingToolkit()
+        register_analysis_tools(toolkit)
+
+        # Test calculate_position_size
+        result = await toolkit.execute(
+            "calculate_position_size",
+            balance=10000.0,
+            entry_price=45000.0,
+            stop_loss=44000.0,
+        )
+        assert result.success is True
+
+        # Test calculate_risk_reward
+        result = await toolkit.execute(
+            "calculate_risk_reward",
+            entry_price=100.0,
+            stop_loss=95.0,
+            take_profit=110.0,
+        )
+        assert result.success is True
+
+        # Test calculate_stop_loss
+        result = await toolkit.execute(
+            "calculate_stop_loss",
+            entry_price=100.0,
+            side="buy",
+        )
+        assert result.success is True
+
+        # Test get_trading_rules
+        result = await toolkit.execute("get_trading_rules")
+        assert result.success is True
+
+        # Test recall_similar_trades
+        result = await toolkit.execute("recall_similar_trades", symbol="BTC/USDT")
+        assert result.success is True
+
+        # Test get_market_patterns
+        result = await toolkit.execute("get_market_patterns")
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_position_size_and_risk_reward_workflow(self):
+        """Test typical workflow combining position size and R:R."""
+        toolkit = TradingToolkit()
+        register_analysis_tools(toolkit)
+
+        # Step 1: Calculate position size
+        size_result = await toolkit.execute(
+            "calculate_position_size",
+            balance=10000.0,
+            entry_price=45000.0,
+            stop_loss=44000.0,
+            risk_pct=0.01,
+        )
+        assert size_result.success is True
+        quantity = size_result.data["quantity"]
+
+        # Step 2: Calculate R:R with take profit
+        rr_result = await toolkit.execute(
+            "calculate_risk_reward",
+            entry_price=45000.0,
+            stop_loss=44000.0,
+            take_profit=47000.0,  # 2:1 target
+            quantity=quantity,
+        )
+        assert rr_result.success is True
+        assert rr_result.data["ratio"] == 2.0

--- a/tests/test_agent/test_execution.py
+++ b/tests/test_agent/test_execution.py
@@ -1,0 +1,411 @@
+"""Tests for execution tools (GUARDED)."""
+
+import pytest
+
+from keryxflow.agent.execution_tools import (
+    CancelOrderTool,
+    CloseAllPositionsTool,
+    ClosePositionTool,
+    PlaceOrderTool,
+    SetStopLossTool,
+    SetTakeProfitTool,
+    register_execution_tools,
+)
+from keryxflow.agent.tools import ToolCategory, TradingToolkit
+
+
+class TestExecutionToolsRegistration:
+    """Tests for execution tools registration."""
+
+    def test_register_execution_tools(self):
+        """Test registering all execution tools."""
+        toolkit = TradingToolkit()
+        register_execution_tools(toolkit)
+
+        execution_tools = toolkit.get_tools_by_category(ToolCategory.EXECUTION)
+        assert len(execution_tools) == 6
+
+    def test_all_execution_tools_are_guarded(self):
+        """Test that all execution tools are guarded."""
+        toolkit = TradingToolkit()
+        register_execution_tools(toolkit)
+
+        for tool in toolkit.get_tools_by_category(ToolCategory.EXECUTION):
+            assert tool.is_guarded is True, f"{tool.name} should be guarded"
+
+
+class TestPlaceOrderTool:
+    """Tests for PlaceOrderTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = PlaceOrderTool()
+
+        assert tool.name == "place_order"
+        assert tool.category == ToolCategory.EXECUTION
+        assert tool.is_guarded is True
+
+    def test_parameters(self):
+        """Test tool parameters."""
+        tool = PlaceOrderTool()
+
+        param_names = [p.name for p in tool.parameters]
+        assert "symbol" in param_names
+        assert "side" in param_names
+        assert "quantity" in param_names
+        assert "order_type" in param_names
+        assert "stop_loss" in param_names
+        assert "take_profit" in param_names
+
+    def test_side_enum(self):
+        """Test side parameter enum values."""
+        tool = PlaceOrderTool()
+        side_param = next(p for p in tool.parameters if p.name == "side")
+        assert side_param.enum == ["buy", "sell"]
+
+    @pytest.mark.asyncio
+    async def test_execute_requires_guardrail_validation(self, init_db):
+        """Test that execution validates against guardrails."""
+        from keryxflow.aegis.risk import get_risk_manager
+        from keryxflow.exchange.paper import get_paper_engine
+
+        # Initialize
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        risk_manager = get_risk_manager(initial_balance=10000.0)
+
+        tool = PlaceOrderTool()
+
+        # This should work - small position within limits
+        result = await tool.execute(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.01,  # Small position
+            stop_loss=44000.0,
+        )
+
+        assert result.success is True
+        assert result.data["symbol"] == "BTC/USDT"
+
+    @pytest.mark.asyncio
+    async def test_execute_blocks_excessive_position(self, init_db):
+        """Test that excessive positions are blocked by guardrails."""
+        from keryxflow.aegis.risk import get_risk_manager
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        risk_manager = get_risk_manager(initial_balance=10000.0)
+
+        tool = PlaceOrderTool()
+
+        # Try to buy way too much - should be blocked
+        result = await tool.execute(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=10.0,  # $450,000 worth - way over limits
+        )
+
+        assert result.success is False
+        assert "guardrail" in result.error.lower() or "risk" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_limit_order_requires_price(self):
+        """Test that limit orders require price parameter."""
+        tool = PlaceOrderTool()
+
+        result = await tool.execute(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.1,
+            order_type="limit",
+            # Missing price
+        )
+
+        assert result.success is False
+        assert "price" in result.error.lower()
+
+
+class TestClosePositionTool:
+    """Tests for ClosePositionTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = ClosePositionTool()
+
+        assert tool.name == "close_position"
+        assert tool.category == ToolCategory.EXECUTION
+        assert tool.is_guarded is True
+
+    @pytest.mark.asyncio
+    async def test_execute_no_position(self, init_db):
+        """Test closing non-existent position."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine()
+        await engine.initialize()
+
+        tool = ClosePositionTool()
+        result = await tool.execute(symbol="BTC/USDT")
+
+        assert result.success is False
+        assert "No open position" in result.error
+
+    @pytest.mark.asyncio
+    async def test_execute_closes_position(self, init_db):
+        """Test closing an existing position."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        # Open a position first
+        await engine.open_position(
+            symbol="BTC/USDT",
+            side="buy",
+            amount=0.1,
+            entry_price=45000.0,
+        )
+
+        # Update price for profit
+        engine.update_price("BTC/USDT", 46000.0)
+
+        tool = ClosePositionTool()
+        result = await tool.execute(symbol="BTC/USDT", reason="Test close")
+
+        assert result.success is True
+        assert result.data["symbol"] == "BTC/USDT"
+        assert "pnl" in result.data
+
+
+class TestSetStopLossTool:
+    """Tests for SetStopLossTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = SetStopLossTool()
+
+        assert tool.name == "set_stop_loss"
+        assert tool.category == ToolCategory.EXECUTION
+        assert tool.is_guarded is True
+
+    @pytest.mark.asyncio
+    async def test_execute_no_position(self, init_db):
+        """Test setting stop loss on non-existent position."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine()
+        await engine.initialize()
+
+        tool = SetStopLossTool()
+        result = await tool.execute(symbol="BTC/USDT", stop_loss=44000.0)
+
+        assert result.success is False
+        assert "No open position" in result.error
+
+    @pytest.mark.asyncio
+    async def test_execute_invalid_stop_direction(self, init_db):
+        """Test setting invalid stop loss direction for long."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        await engine.open_position(
+            symbol="BTC/USDT",
+            side="buy",
+            amount=0.1,
+            entry_price=45000.0,
+        )
+
+        tool = SetStopLossTool()
+        # Stop above entry for long is invalid
+        result = await tool.execute(symbol="BTC/USDT", stop_loss=46000.0)
+
+        assert result.success is False
+        assert "must be below" in result.error.lower()
+
+
+class TestSetTakeProfitTool:
+    """Tests for SetTakeProfitTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = SetTakeProfitTool()
+
+        assert tool.name == "set_take_profit"
+        assert tool.category == ToolCategory.EXECUTION
+        assert tool.is_guarded is True
+
+    @pytest.mark.asyncio
+    async def test_execute_invalid_tp_direction(self, init_db):
+        """Test setting invalid take profit direction for long."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        await engine.open_position(
+            symbol="BTC/USDT",
+            side="buy",
+            amount=0.1,
+            entry_price=45000.0,
+        )
+
+        tool = SetTakeProfitTool()
+        # TP below entry for long is invalid
+        result = await tool.execute(symbol="BTC/USDT", take_profit=44000.0)
+
+        assert result.success is False
+        assert "must be above" in result.error.lower()
+
+
+class TestCancelOrderTool:
+    """Tests for CancelOrderTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = CancelOrderTool()
+
+        assert tool.name == "cancel_order"
+        assert tool.category == ToolCategory.EXECUTION
+        assert tool.is_guarded is True
+
+    def test_requires_order_id_and_symbol(self):
+        """Test that order_id and symbol are required."""
+        tool = CancelOrderTool()
+
+        required_params = [p.name for p in tool.parameters if p.required]
+        assert "order_id" in required_params
+        assert "symbol" in required_params
+
+
+class TestCloseAllPositionsTool:
+    """Tests for CloseAllPositionsTool (panic mode)."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = CloseAllPositionsTool()
+
+        assert tool.name == "close_all_positions"
+        assert tool.category == ToolCategory.EXECUTION
+        assert tool.is_guarded is True
+
+    def test_requires_confirmation(self):
+        """Test that confirmation is required."""
+        tool = CloseAllPositionsTool()
+
+        confirm_param = next(p for p in tool.parameters if p.name == "confirm")
+        assert confirm_param.required is True
+        assert confirm_param.type == "boolean"
+
+    @pytest.mark.asyncio
+    async def test_execute_requires_confirmation(self, init_db):
+        """Test that execution requires confirm=true."""
+        tool = CloseAllPositionsTool()
+
+        result = await tool.execute(reason="Test", confirm=False)
+
+        assert result.success is False
+        assert "not confirmed" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_closes_all(self, init_db):
+        """Test closing all positions."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=100000.0)
+        await engine.initialize()
+
+        # Open multiple positions
+        engine.update_price("BTC/USDT", 45000.0)
+        await engine.open_position(
+            symbol="BTC/USDT",
+            side="buy",
+            amount=0.1,
+            entry_price=45000.0,
+        )
+
+        engine.update_price("ETH/USDT", 3000.0)
+        await engine.open_position(
+            symbol="ETH/USDT",
+            side="buy",
+            amount=1.0,
+            entry_price=3000.0,
+        )
+
+        tool = CloseAllPositionsTool()
+        result = await tool.execute(reason="Emergency exit", confirm=True)
+
+        assert result.success is True
+        assert result.data["closed_count"] == 2
+
+        # Verify no positions remain
+        positions = await engine.get_positions()
+        assert len(positions) == 0
+
+
+class TestExecutionToolsGuardrailIntegration:
+    """Integration tests for execution tools with guardrails."""
+
+    @pytest.mark.asyncio
+    async def test_place_order_respects_max_position_size(self, init_db):
+        """Test that place_order respects MAX_POSITION_SIZE_PCT guardrail."""
+        from keryxflow.aegis.guardrails import get_guardrails
+        from keryxflow.aegis.risk import get_risk_manager
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 100.0)  # Low price for easier math
+
+        risk_manager = get_risk_manager(initial_balance=10000.0)
+        guardrails = get_guardrails()
+
+        tool = PlaceOrderTool()
+
+        # Try to place order larger than MAX_POSITION_SIZE_PCT (10%)
+        # 10000 * 0.10 = 1000 max position value
+        # At $100/BTC, max is 10 BTC
+        # Try to buy 15 BTC ($1500 = 15%)
+        result = await tool.execute(
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=15.0,
+        )
+
+        assert result.success is False
+        # Should be blocked by guardrails or risk manager
+
+    @pytest.mark.asyncio
+    async def test_tools_through_toolkit_with_guardrails(self, init_db):
+        """Test execution tools work through toolkit with guardrails."""
+        from keryxflow.aegis.risk import get_risk_manager
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        risk_manager = get_risk_manager(initial_balance=10000.0)
+
+        toolkit = TradingToolkit()
+        register_execution_tools(toolkit)
+
+        # Small order should work
+        result = await toolkit.execute(
+            "place_order",
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.01,  # ~$450, well under limits
+            stop_loss=44000.0,
+        )
+
+        assert result.success is True

--- a/tests/test_agent/test_executor.py
+++ b/tests/test_agent/test_executor.py
@@ -1,0 +1,328 @@
+"""Tests for the safe tool executor."""
+
+import pytest
+
+from keryxflow.agent.executor import ExecutorStats, ToolExecutor, get_tool_executor
+from keryxflow.agent.tools import (
+    BaseTool,
+    ToolCategory,
+    ToolParameter,
+    ToolResult,
+    TradingToolkit,
+)
+
+
+class MockPerceptionTool(BaseTool):
+    """Mock perception tool for testing."""
+
+    @property
+    def name(self) -> str:
+        return "mock_perception"
+
+    @property
+    def description(self) -> str:
+        return "Mock perception tool"
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.PERCEPTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [ToolParameter("value", "number", "A value", required=True)]
+
+    async def execute(self, **kwargs) -> ToolResult:
+        return ToolResult(success=True, data={"received": kwargs["value"]})
+
+
+class MockExecutionTool(BaseTool):
+    """Mock execution tool for testing."""
+
+    @property
+    def name(self) -> str:
+        return "mock_execution"
+
+    @property
+    def description(self) -> str:
+        return "Mock execution tool"
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.EXECUTION
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return [ToolParameter("action", "string", "An action", required=True)]
+
+    async def execute(self, **kwargs) -> ToolResult:
+        return ToolResult(success=True, data={"action": kwargs["action"]})
+
+
+class FailingTool(BaseTool):
+    """Tool that always fails."""
+
+    @property
+    def name(self) -> str:
+        return "failing_tool"
+
+    @property
+    def description(self) -> str:
+        return "Always fails"
+
+    @property
+    def category(self) -> ToolCategory:
+        return ToolCategory.ANALYSIS
+
+    @property
+    def parameters(self) -> list[ToolParameter]:
+        return []
+
+    async def execute(self, **kwargs) -> ToolResult:
+        raise RuntimeError("Intentional failure")
+
+
+class TestExecutorStats:
+    """Tests for ExecutorStats dataclass."""
+
+    def test_default_values(self):
+        """Test default stats values."""
+        stats = ExecutorStats()
+
+        assert stats.total_executions == 0
+        assert stats.successful_executions == 0
+        assert stats.failed_executions == 0
+        assert stats.blocked_by_guardrails == 0
+
+
+class TestToolExecutor:
+    """Tests for ToolExecutor."""
+
+    def test_init_with_default_toolkit(self):
+        """Test initialization with default toolkit."""
+        executor = ToolExecutor()
+        assert executor.toolkit is not None
+
+    def test_init_with_custom_toolkit(self):
+        """Test initialization with custom toolkit."""
+        toolkit = TradingToolkit()
+        executor = ToolExecutor(toolkit=toolkit)
+        assert executor.toolkit is toolkit
+
+    def test_init_with_rate_limit(self):
+        """Test initialization with custom rate limit."""
+        executor = ToolExecutor(max_executions_per_minute=10)
+        assert executor.max_executions_per_minute == 10
+
+    @pytest.mark.asyncio
+    async def test_execute_perception_tool(self):
+        """Test executing a perception (unguarded) tool."""
+        toolkit = TradingToolkit()
+        toolkit.register(MockPerceptionTool())
+        executor = ToolExecutor(toolkit=toolkit)
+
+        result = await executor.execute("mock_perception", value=42)
+
+        assert result.success is True
+        assert result.data["received"] == 42
+
+    @pytest.mark.asyncio
+    async def test_execute_nonexistent_tool(self):
+        """Test executing a tool that doesn't exist."""
+        executor = ToolExecutor(toolkit=TradingToolkit())
+
+        result = await executor.execute("nonexistent")
+
+        assert result.success is False
+        assert "not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_execute_with_invalid_params(self):
+        """Test executing with invalid parameters."""
+        toolkit = TradingToolkit()
+        toolkit.register(MockPerceptionTool())
+        executor = ToolExecutor(toolkit=toolkit)
+
+        # Missing required parameter
+        result = await executor.execute("mock_perception")
+
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_execute_handles_tool_exception(self):
+        """Test that executor handles tool exceptions gracefully."""
+        toolkit = TradingToolkit()
+        toolkit.register(FailingTool())
+        executor = ToolExecutor(toolkit=toolkit)
+
+        result = await executor.execute("failing_tool")
+
+        assert result.success is False
+        assert "failed" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_stats_tracking(self):
+        """Test that execution stats are tracked."""
+        toolkit = TradingToolkit()
+        toolkit.register(MockPerceptionTool())
+        toolkit.register(FailingTool())
+        executor = ToolExecutor(toolkit=toolkit)
+
+        # Successful execution
+        await executor.execute("mock_perception", value=1)
+        await executor.execute("mock_perception", value=2)
+
+        # Failed execution
+        await executor.execute("failing_tool")
+
+        stats = executor.get_stats()
+        assert stats["total_executions"] == 3
+        assert stats["successful_executions"] == 2
+        assert stats["failed_executions"] == 1
+
+    @pytest.mark.asyncio
+    async def test_rate_limiting(self):
+        """Test rate limiting functionality."""
+        toolkit = TradingToolkit()
+        toolkit.register(MockPerceptionTool())
+        executor = ToolExecutor(toolkit=toolkit, max_executions_per_minute=3)
+
+        # Execute within limits
+        for i in range(3):
+            result = await executor.execute("mock_perception", value=i)
+            assert result.success is True
+
+        # Fourth execution should be rate limited
+        result = await executor.execute("mock_perception", value=99)
+        assert result.success is False
+        assert "Rate limit" in result.error
+
+    @pytest.mark.asyncio
+    async def test_execute_guarded_perception_tool(self):
+        """Test that perception tools skip guardrail check."""
+        toolkit = TradingToolkit()
+        toolkit.register(MockPerceptionTool())
+        executor = ToolExecutor(toolkit=toolkit)
+
+        # Perception tools should work even with skip_guardrails=False
+        result = await executor.execute("mock_perception", skip_guardrails=False, value=42)
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_recent_executions(self):
+        """Test getting recent execution history."""
+        toolkit = TradingToolkit()
+        toolkit.register(MockPerceptionTool())
+        executor = ToolExecutor(toolkit=toolkit)
+
+        await executor.execute("mock_perception", value=1)
+        await executor.execute("mock_perception", value=2)
+
+        recent = executor.get_recent_executions(limit=5)
+
+        assert len(recent) == 2
+        assert recent[0]["tool_name"] == "mock_perception"
+        assert recent[0]["success"] is True
+
+    def test_clear_stats(self):
+        """Test clearing statistics."""
+        executor = ToolExecutor()
+        executor._stats.total_executions = 10
+        executor._stats.successful_executions = 8
+
+        executor.clear_stats()
+
+        stats = executor.get_stats()
+        assert stats["total_executions"] == 0
+        assert stats["successful_executions"] == 0
+
+    @pytest.mark.asyncio
+    async def test_executions_by_category(self):
+        """Test tracking executions by category."""
+        toolkit = TradingToolkit()
+        toolkit.register(MockPerceptionTool())
+        toolkit.register(MockExecutionTool())
+        executor = ToolExecutor(toolkit=toolkit)
+
+        await executor.execute("mock_perception", value=1)
+        await executor.execute("mock_perception", value=2)
+        await executor.execute("mock_execution", skip_guardrails=True, action="test")
+
+        stats = executor.get_stats()
+        assert stats["executions_by_category"]["perception"] == 2
+        assert stats["executions_by_category"]["execution"] == 1
+
+
+class TestToolExecutorWithGuardrails:
+    """Tests for executor with guardrail integration."""
+
+    @pytest.mark.asyncio
+    async def test_execute_guarded_tool_with_guardrails(self, init_db):
+        """Test executing guarded tool validates against guardrails."""
+        from keryxflow.aegis.risk import get_risk_manager
+        from keryxflow.agent.execution_tools import register_execution_tools
+        from keryxflow.exchange.paper import get_paper_engine
+
+        # Setup
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        risk_manager = get_risk_manager(initial_balance=10000.0)
+
+        toolkit = TradingToolkit()
+        register_execution_tools(toolkit)
+        executor = ToolExecutor(toolkit=toolkit)
+
+        # Execute a valid order
+        result = await executor.execute_guarded(
+            "place_order",
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=0.01,
+            stop_loss=44000.0,
+        )
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_execute_guarded_blocks_invalid_order(self, init_db):
+        """Test that guarded execution blocks invalid orders."""
+        from keryxflow.aegis.risk import get_risk_manager
+        from keryxflow.agent.execution_tools import register_execution_tools
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        risk_manager = get_risk_manager(initial_balance=10000.0)
+
+        toolkit = TradingToolkit()
+        register_execution_tools(toolkit)
+        executor = ToolExecutor(toolkit=toolkit)
+
+        # Try to execute an order that exceeds limits
+        result = await executor.execute_guarded(
+            "place_order",
+            symbol="BTC/USDT",
+            side="buy",
+            quantity=10.0,  # Way too much
+        )
+
+        assert result.success is False
+
+
+class TestGlobalExecutor:
+    """Tests for global executor instance."""
+
+    def test_get_tool_executor_singleton(self):
+        """Test that get_tool_executor returns singleton."""
+        # Clear any existing instance
+        import keryxflow.agent.executor as executor_module
+
+        executor_module._executor = None
+
+        executor1 = get_tool_executor()
+        executor2 = get_tool_executor()
+
+        assert executor1 is executor2

--- a/tests/test_agent/test_perception.py
+++ b/tests/test_agent/test_perception.py
@@ -1,0 +1,302 @@
+"""Tests for perception tools."""
+
+import pytest
+
+from keryxflow.agent.perception_tools import (
+    GetBalanceTool,
+    GetCurrentPriceTool,
+    GetOHLCVTool,
+    GetOpenOrdersTool,
+    GetOrderBookTool,
+    GetPortfolioStateTool,
+    GetPositionsTool,
+    register_perception_tools,
+)
+from keryxflow.agent.tools import ToolCategory, TradingToolkit
+
+
+class TestPerceptionToolsRegistration:
+    """Tests for perception tools registration."""
+
+    def test_register_perception_tools(self):
+        """Test registering all perception tools."""
+        toolkit = TradingToolkit()
+        register_perception_tools(toolkit)
+
+        # Should have 7 perception tools
+        perception_tools = toolkit.get_tools_by_category(ToolCategory.PERCEPTION)
+        assert len(perception_tools) == 7
+
+    def test_perception_tools_not_guarded(self):
+        """Test that perception tools are not guarded."""
+        toolkit = TradingToolkit()
+        register_perception_tools(toolkit)
+
+        for tool in toolkit.get_tools_by_category(ToolCategory.PERCEPTION):
+            assert tool.is_guarded is False
+
+
+class TestGetCurrentPriceTool:
+    """Tests for GetCurrentPriceTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = GetCurrentPriceTool()
+
+        assert tool.name == "get_current_price"
+        assert tool.category == ToolCategory.PERCEPTION
+        assert tool.is_guarded is False
+        assert len(tool.parameters) == 1
+        assert tool.parameters[0].name == "symbol"
+
+    def test_anthropic_schema(self):
+        """Test Anthropic schema format."""
+        tool = GetCurrentPriceTool()
+        schema = tool.to_anthropic_schema()
+
+        assert schema["name"] == "get_current_price"
+        assert "symbol" in schema["input_schema"]["properties"]
+        assert "symbol" in schema["input_schema"]["required"]
+
+    @pytest.mark.asyncio
+    async def test_execute_with_paper_engine(self, init_db):
+        """Test execution with paper engine price."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine()
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        tool = GetCurrentPriceTool()
+        result = await tool.execute(symbol="BTC/USDT")
+
+        assert result.success is True
+        assert result.data["symbol"] == "BTC/USDT"
+        assert result.data["price"] == 45000.0
+        assert result.data["source"] == "paper_engine"
+
+
+class TestGetOHLCVTool:
+    """Tests for GetOHLCVTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = GetOHLCVTool()
+
+        assert tool.name == "get_ohlcv"
+        assert tool.category == ToolCategory.PERCEPTION
+        assert len(tool.parameters) == 3
+
+    def test_parameter_defaults(self):
+        """Test parameter defaults."""
+        tool = GetOHLCVTool()
+
+        timeframe_param = next(p for p in tool.parameters if p.name == "timeframe")
+        assert timeframe_param.default == "1h"
+        assert "1h" in timeframe_param.enum
+
+        limit_param = next(p for p in tool.parameters if p.name == "limit")
+        assert limit_param.default == 100
+
+
+class TestGetOrderBookTool:
+    """Tests for GetOrderBookTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = GetOrderBookTool()
+
+        assert tool.name == "get_order_book"
+        assert tool.category == ToolCategory.PERCEPTION
+
+
+class TestGetPortfolioStateTool:
+    """Tests for GetPortfolioStateTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = GetPortfolioStateTool()
+
+        assert tool.name == "get_portfolio_state"
+        assert tool.category == ToolCategory.PERCEPTION
+        assert len(tool.parameters) == 0  # No parameters
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_portfolio_data(self, init_db):
+        """Test that execution returns portfolio state."""
+        from keryxflow.aegis.risk import get_risk_manager
+
+        # Initialize risk manager with some balance
+        risk_manager = get_risk_manager(initial_balance=10000.0)
+
+        tool = GetPortfolioStateTool()
+        result = await tool.execute()
+
+        assert result.success is True
+        assert "total_value" in result.data
+        assert "cash_available" in result.data
+        assert "positions" in result.data
+        assert "timestamp" in result.data
+
+
+class TestGetBalanceTool:
+    """Tests for GetBalanceTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = GetBalanceTool()
+
+        assert tool.name == "get_balance"
+        assert tool.category == ToolCategory.PERCEPTION
+
+    def test_currency_parameter_optional(self):
+        """Test that currency parameter is optional."""
+        tool = GetBalanceTool()
+        param = tool.parameters[0]
+
+        assert param.name == "currency"
+        assert param.required is False
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_balance(self, init_db):
+        """Test that execution returns balance."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+
+        tool = GetBalanceTool()
+        result = await tool.execute()
+
+        assert result.success is True
+        assert "total" in result.data
+        assert "free" in result.data
+        assert "used" in result.data
+
+    @pytest.mark.asyncio
+    async def test_execute_with_specific_currency(self, init_db):
+        """Test execution filtering by currency."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+
+        tool = GetBalanceTool()
+        result = await tool.execute(currency="USDT")
+
+        assert result.success is True
+        assert result.data["currency"] == "USDT"
+        assert "total" in result.data
+
+
+class TestGetPositionsTool:
+    """Tests for GetPositionsTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = GetPositionsTool()
+
+        assert tool.name == "get_positions"
+        assert tool.category == ToolCategory.PERCEPTION
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_empty_list(self, init_db):
+        """Test execution returns empty list when no positions."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine()
+        await engine.initialize()
+
+        tool = GetPositionsTool()
+        result = await tool.execute()
+
+        assert result.success is True
+        assert result.data["positions"] == []
+        assert result.data["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_positions(self, init_db):
+        """Test execution returns open positions."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        # Open a position
+        await engine.open_position(
+            symbol="BTC/USDT",
+            side="buy",
+            amount=0.1,
+            entry_price=45000.0,
+            stop_loss=44000.0,
+        )
+
+        tool = GetPositionsTool()
+        result = await tool.execute()
+
+        assert result.success is True
+        assert result.data["count"] == 1
+        assert result.data["positions"][0]["symbol"] == "BTC/USDT"
+
+
+class TestGetOpenOrdersTool:
+    """Tests for GetOpenOrdersTool."""
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        tool = GetOpenOrdersTool()
+
+        assert tool.name == "get_open_orders"
+        assert tool.category == ToolCategory.PERCEPTION
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_empty_list(self, init_db):
+        """Test execution returns empty list when no orders."""
+        from keryxflow.exchange.orders import get_order_manager
+
+        manager = get_order_manager()
+        await manager.initialize()
+
+        tool = GetOpenOrdersTool()
+        result = await tool.execute()
+
+        assert result.success is True
+        assert result.data["orders"] == []
+        assert result.data["count"] == 0
+
+
+class TestPerceptionToolsIntegration:
+    """Integration tests for perception tools."""
+
+    @pytest.mark.asyncio
+    async def test_tools_can_be_executed_through_toolkit(self, init_db):
+        """Test that all perception tools can be executed through toolkit."""
+        from keryxflow.exchange.paper import get_paper_engine
+
+        engine = get_paper_engine(initial_balance=10000.0)
+        await engine.initialize()
+        engine.update_price("BTC/USDT", 45000.0)
+
+        toolkit = TradingToolkit()
+        register_perception_tools(toolkit)
+
+        # Test get_current_price
+        result = await toolkit.execute("get_current_price", symbol="BTC/USDT")
+        assert result.success is True
+
+        # Test get_balance
+        result = await toolkit.execute("get_balance")
+        assert result.success is True
+
+        # Test get_positions
+        result = await toolkit.execute("get_positions")
+        assert result.success is True
+
+        # Test get_portfolio_state
+        result = await toolkit.execute("get_portfolio_state")
+        assert result.success is True
+
+        # Test get_open_orders
+        result = await toolkit.execute("get_open_orders")
+        assert result.success is True

--- a/tests/test_agent/test_tools.py
+++ b/tests/test_agent/test_tools.py
@@ -1,0 +1,643 @@
+"""Tests for the agent tool framework."""
+
+import pytest
+
+from keryxflow.agent.tools import (
+    BaseTool,
+    ToolCategory,
+    ToolParameter,
+    ToolResult,
+    TradingToolkit,
+    create_tool,
+)
+
+
+class TestToolResult:
+    """Tests for ToolResult dataclass."""
+
+    def test_tool_result_success(self):
+        """Test successful tool result."""
+        result = ToolResult(success=True, data={"price": 45000.0})
+
+        assert result.success is True
+        assert result.data == {"price": 45000.0}
+        assert result.error is None
+
+    def test_tool_result_failure(self):
+        """Test failed tool result."""
+        result = ToolResult(success=False, error="Connection timeout")
+
+        assert result.success is False
+        assert result.error == "Connection timeout"
+        assert result.data is None
+
+    def test_tool_result_to_dict_success(self):
+        """Test to_dict for successful result."""
+        result = ToolResult(success=True, data={"value": 123})
+        d = result.to_dict()
+
+        assert d["success"] is True
+        assert d["data"] == {"value": 123}
+        assert "error" not in d
+
+    def test_tool_result_to_dict_failure(self):
+        """Test to_dict for failed result."""
+        result = ToolResult(success=False, error="Test error")
+        d = result.to_dict()
+
+        assert d["success"] is False
+        assert d["error"] == "Test error"
+
+    def test_tool_result_with_metadata(self):
+        """Test tool result with metadata."""
+        result = ToolResult(
+            success=True,
+            data={"price": 100},
+            metadata={"source": "paper_engine"},
+        )
+        d = result.to_dict()
+
+        assert d["metadata"] == {"source": "paper_engine"}
+
+
+class TestToolParameter:
+    """Tests for ToolParameter dataclass."""
+
+    def test_basic_parameter(self):
+        """Test basic parameter creation."""
+        param = ToolParameter(
+            name="symbol",
+            type="string",
+            description="Trading pair",
+            required=True,
+        )
+
+        assert param.name == "symbol"
+        assert param.type == "string"
+        assert param.required is True
+        assert param.enum is None
+
+    def test_parameter_with_enum(self):
+        """Test parameter with enum values."""
+        param = ToolParameter(
+            name="side",
+            type="string",
+            description="Order side",
+            required=True,
+            enum=["buy", "sell"],
+        )
+
+        assert param.enum == ["buy", "sell"]
+
+    def test_parameter_with_default(self):
+        """Test parameter with default value."""
+        param = ToolParameter(
+            name="limit",
+            type="integer",
+            description="Limit",
+            required=False,
+            default=100,
+        )
+
+        assert param.required is False
+        assert param.default == 100
+
+
+class TestBaseTool:
+    """Tests for BaseTool abstract class."""
+
+    def test_create_concrete_tool(self):
+        """Test creating a concrete tool implementation."""
+
+        class MockTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "mock_tool"
+
+            @property
+            def description(self) -> str:
+                return "A mock tool for testing"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return [
+                    ToolParameter("param1", "string", "First param", required=True),
+                    ToolParameter("param2", "number", "Second param", required=False),
+                ]
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True, data={"received": kwargs})
+
+        tool = MockTool()
+
+        assert tool.name == "mock_tool"
+        assert tool.category == ToolCategory.PERCEPTION
+        assert tool.is_guarded is False
+        assert len(tool.parameters) == 2
+
+    def test_execution_tool_is_guarded(self):
+        """Test that execution tools are guarded."""
+
+        class ExecutionTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "exec_tool"
+
+            @property
+            def description(self) -> str:
+                return "Execution tool"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.EXECUTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return []
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        tool = ExecutionTool()
+        assert tool.is_guarded is True
+
+    def test_to_anthropic_schema(self):
+        """Test conversion to Anthropic Tool Use API format."""
+
+        class TestTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "test_tool"
+
+            @property
+            def description(self) -> str:
+                return "Test tool description"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.ANALYSIS
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return [
+                    ToolParameter("symbol", "string", "Trading pair", required=True),
+                    ToolParameter(
+                        "side", "string", "Side", required=True, enum=["buy", "sell"]
+                    ),
+                    ToolParameter("limit", "integer", "Limit", required=False, default=10),
+                ]
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        tool = TestTool()
+        schema = tool.to_anthropic_schema()
+
+        assert schema["name"] == "test_tool"
+        assert schema["description"] == "Test tool description"
+        assert schema["input_schema"]["type"] == "object"
+        assert "symbol" in schema["input_schema"]["properties"]
+        assert schema["input_schema"]["properties"]["side"]["enum"] == ["buy", "sell"]
+        assert schema["input_schema"]["required"] == ["symbol", "side"]
+
+    def test_validate_parameters_success(self):
+        """Test parameter validation success."""
+
+        class TestTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "test"
+
+            @property
+            def description(self) -> str:
+                return "Test"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return [
+                    ToolParameter("symbol", "string", "Symbol", required=True),
+                    ToolParameter("limit", "integer", "Limit", required=False),
+                ]
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        tool = TestTool()
+        is_valid, error = tool.validate_parameters(symbol="BTC/USDT", limit=50)
+
+        assert is_valid is True
+        assert error is None
+
+    def test_validate_parameters_missing_required(self):
+        """Test parameter validation with missing required param."""
+
+        class TestTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "test"
+
+            @property
+            def description(self) -> str:
+                return "Test"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return [
+                    ToolParameter("symbol", "string", "Symbol", required=True),
+                ]
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        tool = TestTool()
+        is_valid, error = tool.validate_parameters()
+
+        assert is_valid is False
+        assert "symbol" in error
+
+    def test_validate_parameters_invalid_enum(self):
+        """Test parameter validation with invalid enum value."""
+
+        class TestTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "test"
+
+            @property
+            def description(self) -> str:
+                return "Test"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return [
+                    ToolParameter(
+                        "side", "string", "Side", required=True, enum=["buy", "sell"]
+                    ),
+                ]
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        tool = TestTool()
+        is_valid, error = tool.validate_parameters(side="invalid")
+
+        assert is_valid is False
+        assert "must be one of" in error
+
+
+class TestTradingToolkit:
+    """Tests for TradingToolkit."""
+
+    def test_register_tool(self):
+        """Test registering a tool."""
+        toolkit = TradingToolkit()
+
+        class MockTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "mock"
+
+            @property
+            def description(self) -> str:
+                return "Mock"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return []
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        tool = MockTool()
+        toolkit.register(tool)
+
+        assert toolkit.tool_count == 1
+        assert toolkit.get_tool("mock") is tool
+
+    def test_register_duplicate_raises(self):
+        """Test that registering duplicate tool raises error."""
+        toolkit = TradingToolkit()
+
+        class MockTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "mock"
+
+            @property
+            def description(self) -> str:
+                return "Mock"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return []
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        toolkit.register(MockTool())
+
+        with pytest.raises(ValueError, match="already registered"):
+            toolkit.register(MockTool())
+
+    def test_get_tools_by_category(self):
+        """Test getting tools by category."""
+        toolkit = TradingToolkit()
+
+        class PerceptionTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "perception"
+
+            @property
+            def description(self) -> str:
+                return "Perception"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return []
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        class ExecutionTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "execution"
+
+            @property
+            def description(self) -> str:
+                return "Execution"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.EXECUTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return []
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        toolkit.register(PerceptionTool())
+        toolkit.register(ExecutionTool())
+
+        perception_tools = toolkit.get_tools_by_category(ToolCategory.PERCEPTION)
+        execution_tools = toolkit.get_tools_by_category(ToolCategory.EXECUTION)
+
+        assert len(perception_tools) == 1
+        assert len(execution_tools) == 1
+        assert perception_tools[0].name == "perception"
+
+    def test_get_guarded_tools(self):
+        """Test getting guarded tools."""
+        toolkit = TradingToolkit()
+
+        class SafeTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "safe"
+
+            @property
+            def description(self) -> str:
+                return "Safe"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.ANALYSIS
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return []
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        class GuardedTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "guarded"
+
+            @property
+            def description(self) -> str:
+                return "Guarded"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.EXECUTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return []
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        toolkit.register(SafeTool())
+        toolkit.register(GuardedTool())
+
+        guarded = toolkit.get_guarded_tools()
+        assert len(guarded) == 1
+        assert guarded[0].name == "guarded"
+
+    def test_get_anthropic_tools_schema(self):
+        """Test getting Anthropic API format schemas."""
+        toolkit = TradingToolkit()
+
+        class Tool1(BaseTool):
+            @property
+            def name(self) -> str:
+                return "tool1"
+
+            @property
+            def description(self) -> str:
+                return "Tool 1"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return [ToolParameter("param", "string", "Param", required=True)]
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        toolkit.register(Tool1())
+        schemas = toolkit.get_anthropic_tools_schema()
+
+        assert len(schemas) == 1
+        assert schemas[0]["name"] == "tool1"
+        assert "input_schema" in schemas[0]
+
+    @pytest.mark.asyncio
+    async def test_execute_tool(self):
+        """Test executing a tool through the toolkit."""
+        toolkit = TradingToolkit()
+
+        class AddTool(BaseTool):
+            @property
+            def name(self) -> str:
+                return "add"
+
+            @property
+            def description(self) -> str:
+                return "Add two numbers"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.ANALYSIS
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return [
+                    ToolParameter("a", "number", "First number", required=True),
+                    ToolParameter("b", "number", "Second number", required=True),
+                ]
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True, data={"sum": kwargs["a"] + kwargs["b"]})
+
+        toolkit.register(AddTool())
+        result = await toolkit.execute("add", a=5, b=3)
+
+        assert result.success is True
+        assert result.data["sum"] == 8
+
+    @pytest.mark.asyncio
+    async def test_execute_nonexistent_tool(self):
+        """Test executing a tool that doesn't exist."""
+        toolkit = TradingToolkit()
+        result = await toolkit.execute("nonexistent")
+
+        assert result.success is False
+        assert "not found" in result.error
+
+    def test_list_tools(self):
+        """Test listing tools by category."""
+        toolkit = TradingToolkit()
+
+        class Tool1(BaseTool):
+            @property
+            def name(self) -> str:
+                return "tool1"
+
+            @property
+            def description(self) -> str:
+                return "Tool1"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return []
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        class Tool2(BaseTool):
+            @property
+            def name(self) -> str:
+                return "tool2"
+
+            @property
+            def description(self) -> str:
+                return "Tool2"
+
+            @property
+            def category(self) -> ToolCategory:
+                return ToolCategory.PERCEPTION
+
+            @property
+            def parameters(self) -> list[ToolParameter]:
+                return []
+
+            async def execute(self, **kwargs):
+                return ToolResult(success=True)
+
+        toolkit.register(Tool1())
+        toolkit.register(Tool2())
+
+        tools_list = toolkit.list_tools()
+        assert "perception" in tools_list
+        assert "tool1" in tools_list["perception"]
+        assert "tool2" in tools_list["perception"]
+
+
+class TestCreateToolDecorator:
+    """Tests for the create_tool decorator."""
+
+    @pytest.mark.asyncio
+    async def test_create_tool_decorator(self):
+        """Test creating a tool with the decorator."""
+
+        @create_tool(
+            name="get_answer",
+            description="Returns the answer to everything",
+            category=ToolCategory.ANALYSIS,
+            parameters=[],
+        )
+        async def get_answer() -> ToolResult:
+            return ToolResult(success=True, data={"answer": 42})
+
+        tool = get_answer  # The decorator returns the tool instance
+
+        assert tool.name == "get_answer"
+        assert tool.category == ToolCategory.ANALYSIS
+
+        result = await tool.execute()
+        assert result.success is True
+        assert result.data["answer"] == 42
+
+    @pytest.mark.asyncio
+    async def test_create_tool_with_params(self):
+        """Test creating a tool with parameters."""
+
+        @create_tool(
+            name="multiply",
+            description="Multiply two numbers",
+            category=ToolCategory.ANALYSIS,
+            parameters=[
+                ToolParameter("a", "number", "First number", required=True),
+                ToolParameter("b", "number", "Second number", required=True),
+            ],
+        )
+        async def multiply(a: float, b: float) -> ToolResult:
+            return ToolResult(success=True, data={"result": a * b})
+
+        tool = multiply
+        result = await tool.execute(a=7, b=6)
+
+        assert result.success is True
+        assert result.data["result"] == 42


### PR DESCRIPTION
…se 3)

Add comprehensive tool framework for cognitive agent with 20 tools:

Perception Tools (7):
- get_current_price, get_ohlcv, get_order_book
- get_portfolio_state, get_balance, get_positions, get_open_orders

Analysis Tools (7):
- calculate_indicators, calculate_position_size, calculate_risk_reward
- calculate_stop_loss, get_trading_rules, recall_similar_trades
- get_market_patterns

Execution Tools (6) - GUARDED:
- place_order, close_position, set_stop_loss, set_take_profit
- cancel_order, close_all_positions

Features:
- BaseTool abstract class with Anthropic Tool Use API compatible schema
- TradingToolkit for tool registration and management
- ToolExecutor with guardrail validation for execution tools
- Rate limiting and execution statistics tracking
- Full async/await support throughout